### PR TITLE
feat: EntryID and cron.nextID renaming

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -123,6 +123,7 @@ func New(opts ...Option) *Cron {
 		logger:    DefaultLogger,
 		location:  time.Local,
 		parser:    standardParser,
+		next: 1,
 	}
 	for _, opt := range opts {
 		opt(c)
@@ -158,13 +159,13 @@ func (c *Cron) AddJob(spec string, cmd Job) (ID, error) {
 func (c *Cron) Schedule(schedule Schedule, cmd Job) ID {
 	c.runningMu.Lock()
 	defer c.runningMu.Unlock()
-	c.next++
 	entry := &Entry{
 		ID:         c.next,
 		Schedule:   schedule,
 		WrappedJob: c.chain.Then(cmd),
 		Job:        cmd,
 	}
+	c.next++
 	if !c.running {
 		c.entries = append(c.entries, entry)
 	} else {

--- a/cron.go
+++ b/cron.go
@@ -22,7 +22,7 @@ type Cron struct {
 	runningMu sync.Mutex
 	location  *time.Location
 	parser    ScheduleParser
-	nextID    ID
+	next    ID
 	jobWaiter sync.WaitGroup
 }
 
@@ -158,9 +158,9 @@ func (c *Cron) AddJob(spec string, cmd Job) (ID, error) {
 func (c *Cron) Schedule(schedule Schedule, cmd Job) ID {
 	c.runningMu.Lock()
 	defer c.runningMu.Unlock()
-	c.nextID++
+	c.next++
 	entry := &Entry{
-		ID:         c.nextID,
+		ID:         c.next,
 		Schedule:   schedule,
 		WrappedJob: c.chain.Then(cmd),
 		Job:        cmd,


### PR DESCRIPTION
- Renamed `EntryID` to `ID`. It identifies the main concept of a scheduled job and does not need an `Entry` prefix IMO.
- Renamed `cron.nextID` to `cron.next`. It's a variable of type `ID` and therefore this information does not necessarily need to be repeated.
- `cron.next` now contains the next value to be used, not the last used one.