### PR TITLE
feat(entry): remove valid() method

### DIFF
--- a/cron.go
+++ b/cron.go
@@ -39,7 +39,7 @@ type Schedule interface {
 }
 
 // ID identifies an entry within a Cron instance
-type ID int
+type ID uint
 
 // Entry consists of a schedule and the func to execute on that schedule.
 type Entry struct {

--- a/cron_test.go
+++ b/cron_test.go
@@ -318,9 +318,18 @@ func TestRunningMultipleSchedules(t *testing.T) {
 	if err != nil {
 		t.Error("non-nil error")
 	}
-	cron.Schedule(Every(time.Minute), func() {})
-	cron.Schedule(Every(time.Second), func() { wg.Done() })
-	cron.Schedule(Every(time.Hour), func() {})
+	_, err = cron.Schedule(Every(time.Minute), func() {})
+	if err != nil {
+		t.Error("non-nil error")
+	}
+	_, err = cron.Schedule(Every(time.Second), func() { wg.Done() })
+	if err != nil {
+		t.Error("non-nil error")
+	}
+	_, err = cron.Schedule(Every(time.Hour), func() {})
+	if err != nil {
+		t.Error("non-nil error")
+	}
 
 	cron.Start()
 	defer cron.Stop()
@@ -508,8 +517,14 @@ func TestJob(t *testing.T) {
 	if err != nil {
 		t.Error("non-nil error")
 	}
-	job4 := cron.Schedule(Every(5*time.Second+5*time.Nanosecond), newTestJob(wg, "job4").job())
-	job5 := cron.Schedule(Every(5*time.Minute), newTestJob(wg, "job5").job())
+	job4, err := cron.Schedule(Every(5*time.Second+5*time.Nanosecond), newTestJob(wg, "job4").job())
+	if err != nil {
+		t.Error("non-nil error")
+	}
+	job5, err := cron.Schedule(Every(5*time.Minute), newTestJob(wg, "job5").job())
+	if err != nil {
+		t.Error("non-nil error")
+	}
 
 	cron.Start()
 	defer cron.Stop()
@@ -551,8 +566,11 @@ func TestScheduleAfterRemoval(t *testing.T) {
 	var mu sync.Mutex
 
 	cron := newWithSeconds()
-	hourJob := cron.Schedule(Every(time.Hour), func() {})
-	cron.Schedule(Every(time.Second), func() {
+	hourJob, err := cron.Schedule(Every(time.Hour), func() {})
+	if err != nil {
+		t.Error("non-nil error")
+	}
+	_, err = cron.Schedule(Every(time.Second), func() {
 		mu.Lock()
 		defer mu.Unlock()
 		switch calls {
@@ -570,6 +588,9 @@ func TestScheduleAfterRemoval(t *testing.T) {
 			panic("unexpected 3rd call")
 		}
 	})
+	if err != nil {
+		t.Error("non-nil error")
+	}
 
 	cron.Start()
 	defer cron.Stop()
@@ -599,7 +620,10 @@ func TestJobWithZeroTimeDoesNotRun(t *testing.T) {
 	if err != nil {
 		t.Error("non-nil error")
 	}
-	cron.Schedule(new(ZeroSchedule), func() { t.Error("expected zero task will not run") })
+	_, err = cron.Schedule(new(ZeroSchedule), func() { t.Error("expected zero task will not run") })
+	if err != nil {
+		t.Error("non-nil error")
+	}
 	cron.Start()
 	defer cron.Stop()
 	<-time.After(OneSecond)

--- a/cron_test.go
+++ b/cron_test.go
@@ -785,6 +785,20 @@ func TestMultiThreadedStartAndStop(t *testing.T) {
 	cron.Stop()
 }
 
+func TestRunningOutOfIDs(t *testing.T) {
+	cron := New()
+	cron.next = ID(^uint(0))
+
+	_, err := cron.Add("* * * * *", func() {})
+	if err != nil {
+		t.Error("non-nil error")
+	}
+	_, err = cron.Add("* * * * *", func() {})
+	if err == nil {
+		t.Error("expected error, got nil")
+	}
+}
+
 func wait(wg *sync.WaitGroup) chan bool {
 	ch := make(chan bool)
 	go func() {


### PR DESCRIPTION
Return an error instead of creating invalid entries when running out of IDs.