### PR TITLE
feat: Prevent the creation of constant delay schedules that are not a multiple of one second.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+.idea
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/constantdelay.go
+++ b/constantdelay.go
@@ -1,27 +1,29 @@
 package cron
 
-import "time"
+import (
+	"fmt"
+	"time"
+)
 
-// ConstantDelaySchedule represents a simple recurring duty cycle, e.g. "Every 5 minutes".
+// constantDelaySchedule represents a simple recurring duty cycle, e.g. "Every 5 minutes".
 // It does not support jobs more frequent than once a second.
-type ConstantDelaySchedule struct {
+type constantDelaySchedule struct {
 	Delay time.Duration
 }
 
-// Every returns a crontab Schedule that activates once every duration.
-// Delays of less than a second are not supported (will round up to 1 second).
-// Any fields less than a Second are truncated.
-func Every(duration time.Duration) ConstantDelaySchedule {
+// every returns a crontab Schedule that activates once every duration.
+// Delays that are less than on second or not a multiple of a second will return an error.
+func every(duration time.Duration) (Schedule, error) {
 	if duration < time.Second {
-		duration = time.Second
+		return nil, fmt.Errorf("delay must be at least one second but was %s", duration.String())
+	} else if duration%time.Second != 0 {
+		return nil, fmt.Errorf("delay must be a multiple of one second but was %s", duration.String())
 	}
-	return ConstantDelaySchedule{
-		Delay: duration - time.Duration(duration.Nanoseconds())%time.Second,
-	}
+	return constantDelaySchedule{Delay: duration}, nil
 }
 
 // Next returns the next time this should be run.
 // This rounds so that the next activation time will be on the second.
-func (schedule ConstantDelaySchedule) Next(t time.Time) time.Time {
+func (schedule constantDelaySchedule) Next(t time.Time) time.Time {
 	return t.Add(schedule.Delay - time.Duration(t.Nanosecond())*time.Nanosecond)
 }

--- a/cron_test.go
+++ b/cron_test.go
@@ -319,15 +319,15 @@ func TestRunningMultipleSchedules(t *testing.T) {
 	if err != nil {
 		t.Error("non-nil error")
 	}
-	_, err = cron.Schedule(Every(time.Minute), func() {})
+	_, err = cron.Schedule(must(every(time.Minute)), func() {})
 	if err != nil {
 		t.Error("non-nil error")
 	}
-	_, err = cron.Schedule(Every(time.Second), func() { wg.Done() })
+	_, err = cron.Schedule(must(every(time.Second)), func() { wg.Done() })
 	if err != nil {
 		t.Error("non-nil error")
 	}
-	_, err = cron.Schedule(Every(time.Hour), func() {})
+	_, err = cron.Schedule(must(every(time.Hour)), func() {})
 	if err != nil {
 		t.Error("non-nil error")
 	}
@@ -518,11 +518,11 @@ func TestJob(t *testing.T) {
 	if err != nil {
 		t.Error("non-nil error")
 	}
-	job4, err := cron.Schedule(Every(5*time.Second+5*time.Nanosecond), newTestJob(wg, "job4").job())
+	job4, err := cron.Add("@every 5s", newTestJob(wg, "job4").job())
 	if err != nil {
 		t.Error("non-nil error")
 	}
-	job5, err := cron.Schedule(Every(5*time.Minute), newTestJob(wg, "job5").job())
+	job5, err := cron.Schedule(must(every(5*time.Minute)), newTestJob(wg, "job5").job())
 	if err != nil {
 		t.Error("non-nil error")
 	}
@@ -568,11 +568,11 @@ func TestScheduleAfterRemoval(t *testing.T) {
 	var mu sync.Mutex
 
 	cron := newWithSeconds()
-	hourJob, err := cron.Schedule(Every(time.Hour), func() {})
+	hourJob, err := cron.Schedule(must(every(time.Hour)), func() {})
 	if err != nil {
 		t.Error("non-nil error")
 	}
-	_, err = cron.Schedule(Every(time.Second), func() {
+	_, err = cron.Schedule(must(every(time.Second)), func() {
 		mu.Lock()
 		defer mu.Unlock()
 		switch calls {
@@ -822,4 +822,11 @@ func stop(cron *Cron) chan bool {
 // newWithSeconds returns a Cron with the seconds field enabled.
 func newWithSeconds() *Cron {
 	return New(WithParser(secondParser), WithChain())
+}
+
+func must[T any](val T, err error) T {
+	if err != nil {
+		panic(err)
+	}
+	return val
 }

--- a/parser.go
+++ b/parser.go
@@ -421,13 +421,13 @@ func parseDescriptor(descriptor string, loc *time.Location) (Schedule, error) {
 
 	}
 
-	const every = "@every "
-	if strings.HasPrefix(descriptor, every) {
-		duration, err := time.ParseDuration(descriptor[len(every):])
+	const everyPrefix = "@every "
+	if strings.HasPrefix(descriptor, everyPrefix) {
+		duration, err := time.ParseDuration(descriptor[len(everyPrefix):])
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse duration %s: %s", descriptor, err)
 		}
-		return Every(duration), nil
+		return every(duration)
 	}
 
 	return nil, fmt.Errorf("unrecognized descriptor: %s", descriptor)

--- a/parser_test.go
+++ b/parser_test.go
@@ -122,6 +122,8 @@ func TestParseScheduleErrors(t *testing.T) {
 	var tests = []struct{ expr, err string }{
 		{"* 5 j * * *", "failed to parse int from"},
 		{"@every Xm", "failed to parse duration"},
+		{"@every 1ns", "delay must be at least one second"},
+		{"@every 1h1ms", "delay must be a multiple of one second"},
 		{"@unrecognized", "unrecognized descriptor"},
 		{"* * * *", "expected 5 to 6 fields"},
 		{"", "empty spec string"},
@@ -149,7 +151,7 @@ func TestParseSchedule(t *testing.T) {
 		{secondParser, "CRON_TZ=UTC  0 5 * * * *", every5min(time.UTC)},
 		{standardParser, "CRON_TZ=UTC  5 * * * *", every5min(time.UTC)},
 		{secondParser, "CRON_TZ=Asia/Tokyo 0 5 * * * *", every5min(tokyo)},
-		{secondParser, "@every 5m", ConstantDelaySchedule{5 * time.Minute}},
+		{secondParser, "@every 5m", constantDelaySchedule{5 * time.Minute}},
 		{secondParser, "@midnight", midnight(time.Local)},
 		{secondParser, "TZ=UTC  @midnight", midnight(time.UTC)},
 		{secondParser, "TZ=Asia/Tokyo @midnight", midnight(tokyo)},
@@ -324,7 +326,7 @@ func TestStandardSpecSchedule(t *testing.T) {
 		},
 		{
 			expr:     "@every 5m",
-			expected: ConstantDelaySchedule{time.Duration(5) * time.Minute},
+			expected: constantDelaySchedule{time.Duration(5) * time.Minute},
 		},
 		{
 			expr: "5 j * * *",


### PR DESCRIPTION
As this is not supported anyway by this library it might lead to confusing behaviour

closes #21 