### PR TITLE
feat: matcher funcs instead of bitset configs and SpecSchedule private

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+.vscode

--- a/internal/matcher/matcher.go
+++ b/internal/matcher/matcher.go
@@ -1,0 +1,27 @@
+package matcher
+
+import "time"
+
+type Matcher func(time.Time) bool
+
+func Or(matchers ...Matcher) Matcher {
+	return func(t time.Time) bool {
+		for _, m := range matchers {
+			if m(t) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+func And(matchers ...Matcher) Matcher {
+	return func(t time.Time) bool {
+		for _, m := range matchers {
+			if !m(t) {
+				return false
+			}
+		}
+		return true
+	}
+}

--- a/internal/parser/day.go
+++ b/internal/parser/day.go
@@ -1,0 +1,34 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/gdgvda/cron/internal/matcher"
+)
+
+func ParseDay(dom, dow string) (matcher.Matcher, error) {
+	domMatcher, err := ParseDom(dom)
+	if err != nil {
+		return nil, err
+	}
+	dowMatcher, err := ParseDow(dow)
+	if err != nil {
+		return nil, err
+	}
+
+	doms := strings.FieldsFunc(dom, func(r rune) bool { return r == ',' })
+	for _, v := range doms {
+		if v == "*" || v == "?" {
+			return matcher.And(domMatcher, dowMatcher), nil
+		}
+	}
+
+	dows := strings.FieldsFunc(dow, func(r rune) bool { return r == ',' })
+	for _, v := range dows {
+		if v == "*" || v == "?" {
+			return matcher.And(domMatcher, dowMatcher), nil
+		}
+	}
+
+	return matcher.Or(domMatcher, dowMatcher), nil
+}

--- a/internal/parser/day_test.go
+++ b/internal/parser/day_test.go
@@ -1,0 +1,50 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseDayMatcher(t *testing.T) {
+	tests := []struct {
+		dom      string
+		dow      string
+		time     string
+		expected bool
+	}{
+		{"*", "Mon", "Thu Jan 2 2025", false},
+		{"*", "Thu", "Thu Jan 2 2025", true},
+		{"2", "*", "Fri Jan 3 2025", false},
+		{"3", "*", "Fri Jan 3 2025", true},
+		{"1", "Thu", "Thu Jan 2 2025", true},
+		{"2", "Sat", "Thu Jan 2 2025", true},
+	}
+
+	const layout = "Mon Jan 2 2006"
+	for _, test := range tests {
+		t.Run(fmt.Sprintf(
+			"dom=%s,dow=%s,now=%s",
+			strings.Replace(test.dom, "/", "|", -1),
+			strings.Replace(test.dow, "/", "|", -1),
+			test.time,
+		), func(t *testing.T) {
+			time, err := time.Parse(layout, test.time)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			matcher, err := ParseDay(test.dom, test.dow)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			actual := matcher(time)
+			if actual != test.expected {
+				t.Fatalf("dom=%s, dow=%s, time=%s, expected=%t, got=%t",
+					test.dom, test.dow, test.time, test.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/parser/dom.go
+++ b/internal/parser/dom.go
@@ -1,0 +1,63 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gdgvda/cron/internal/matcher"
+)
+
+var domToInt = map[string]uint{}
+
+func ParseDom(expression string) (matcher.Matcher, error) {
+	options := strings.FieldsFunc(expression, func(r rune) bool { return r == ',' })
+	matches := []matcher.Matcher{}
+	for _, option := range options {
+		match, err := parseDom(option)
+		if err != nil {
+			return nil, err
+		}
+		matches = append(matches, match)
+	}
+	return matcher.Or(matches...), nil
+}
+
+func parseDom(expression string) (matcher.Matcher, error) {
+	rangeAndStep := strings.Split(expression, "/")
+	lowAndHigh := strings.Split(rangeAndStep[0], "-")
+
+	if len(lowAndHigh) > 2 || len(rangeAndStep) > 2 {
+		return nil, fmt.Errorf("%s: invalid expression", expression)
+	}
+
+	if lowAndHigh[0] == "*" || lowAndHigh[0] == "?" {
+		if len(lowAndHigh) > 1 {
+			return nil, fmt.Errorf("%s: invalid expression", expression)
+		}
+		lowAndHigh[0] = "1-31"
+	} else {
+		if len(lowAndHigh) == 1 && len(rangeAndStep) == 2 {
+			lowAndHigh[0] += "-31"
+		}
+	}
+
+	expression = strings.Join(lowAndHigh, "-")
+	if len(rangeAndStep) > 1 {
+		expression += "/" + rangeAndStep[1]
+	}
+
+	activations, err := span(expression, 1, 31, domToInt)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(t time.Time) bool {
+		for _, dom := range activations {
+			if uint(t.Day()) == dom {
+				return true
+			}
+		}
+		return false
+	}, nil
+}

--- a/internal/parser/dom_test.go
+++ b/internal/parser/dom_test.go
@@ -1,0 +1,114 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseDomMatcher(t *testing.T) {
+	tests := []struct {
+		spec     string
+		time     string
+		expected bool
+	}{
+		{"*", "Nov 3", true},
+		{"*", "Dec 25", true},
+		{"?", "Nov 3", true},
+		{"?", "Dec 25", true},
+
+		{"23", "Dec 23", true},
+		{"23", "Oct 23", true},
+		{"7", "Oct 23", false},
+		{"18", "Aug 18", true},
+
+		{"11-12", "Sep 10", false},
+		{"11-12", "Sep 11", true},
+		{"11-12", "Sep 12", true},
+		{"11-12", "Sep 13", false},
+		{"1-23", "Feb 17", true},
+
+		{"1/5", "Mar 1", true},
+		{"1/5", "Mar 6", true},
+		{"1/5", "Mar 7", false},
+		{"*/5", "Mar 1", true},
+		{"*/5", "Mar 6", true},
+		{"*/5", "Mar 7", false},
+		{"5/5", "Jan 5", true},
+		{"5/5", "Jan 2", false},
+		{"5/5", "Jan 10", true},
+		{"5/5", "Feb 8", false},
+
+		{"5-17/5", "Apr 5", true},
+		{"5-17/5", "May 10", true},
+		{"5-17/5", "Aug 20", false},
+
+		{"5-17/5,20", "Aug 20", true},
+		{"5-17/5,19", "Aug 20", false},
+
+		{"1,2,3", "Jan 4", false},
+		{"1,2,3", "Jan 2", true},
+		{"1,02,3", "Jan 2", true},
+	}
+
+	const layout = "Jan 2"
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("spec=%s,now=%s", strings.Replace(test.spec, "/", "|", -1), test.time), func(t *testing.T) {
+			time, err := time.Parse(layout, test.time)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			matcher, err := ParseDom(test.spec)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			actual := matcher(time)
+			if actual != test.expected {
+				t.Fatalf("spec=%s, time=%s, expected=%t, got=%t",
+					test.spec, test.time, test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestParseDomErrors(t *testing.T) {
+	tests := []struct {
+		spec     string
+		expected string
+	}{
+		{"#", "failed to parse"},
+		{"*-5", "invalid expression"},
+		{"*-5/2", "invalid expression"},
+		{"5-*", "failed to parse"},
+		{"5-*/22", "failed to parse"},
+		{"-1", "failed to parse"},
+		{"-22", "failed to parse"},
+		{"32", "value 32 out of valid range [1, 31]"},
+		{"22-32", "value 32 out of valid range [1, 31]"},
+		{"22-33/36", "value 33 out of valid range [1, 31]"},
+		{"22-23/ABC", "failed to parse"},
+		{"*//2", "invalid expression"},
+		{"*/2/", "invalid expression"},
+		{"*-2-", "invalid expression"},
+		{"2-", "failed to parse"},
+		{"1-2-", "invalid expression"},
+	}
+
+	for _, test := range tests {
+		t.Run(strings.Replace(test.spec, "/", "|", -1), func(t *testing.T) {
+			_, err := ParseDom(test.spec)
+			if err == nil {
+				t.Fatal("expected non-nil error, got nil")
+			}
+
+			actual := err.Error()
+			if !strings.Contains(actual, test.expected) {
+				t.Fatalf("spec=%s, expectedError=%s, gotError=%s",
+					test.spec, test.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/parser/dow.go
+++ b/internal/parser/dow.go
@@ -1,0 +1,71 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gdgvda/cron/internal/matcher"
+)
+
+var dowToInt = map[string]uint{
+	"sun": 0,
+	"mon": 1,
+	"tue": 2,
+	"wed": 3,
+	"thu": 4,
+	"fri": 5,
+	"sat": 6,
+}
+
+func ParseDow(expression string) (matcher.Matcher, error) {
+	options := strings.FieldsFunc(expression, func(r rune) bool { return r == ',' })
+	matches := []matcher.Matcher{}
+	for _, option := range options {
+		match, err := parseDow(option)
+		if err != nil {
+			return nil, err
+		}
+		matches = append(matches, match)
+	}
+	return matcher.Or(matches...), nil
+}
+
+func parseDow(expression string) (matcher.Matcher, error) {
+	rangeAndStep := strings.Split(expression, "/")
+	lowAndHigh := strings.Split(rangeAndStep[0], "-")
+
+	if len(lowAndHigh) > 2 || len(rangeAndStep) > 2 {
+		return nil, fmt.Errorf("%s: invalid expression", expression)
+	}
+
+	if lowAndHigh[0] == "*" || lowAndHigh[0] == "?" {
+		if len(lowAndHigh) > 1 {
+			return nil, fmt.Errorf("%s: invalid expression", expression)
+		}
+		lowAndHigh[0] = "0-6"
+	} else {
+		if len(lowAndHigh) == 1 && len(rangeAndStep) == 2 {
+			lowAndHigh[0] += "-6"
+		}
+	}
+
+	expression = strings.Join(lowAndHigh, "-")
+	if len(rangeAndStep) > 1 {
+		expression += "/" + rangeAndStep[1]
+	}
+
+	activations, err := span(expression, 0, 6, dowToInt)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(t time.Time) bool {
+		for _, dow := range activations {
+			if t.Weekday() == time.Weekday(dow) {
+				return true
+			}
+		}
+		return false
+	}, nil
+}

--- a/internal/parser/dow_test.go
+++ b/internal/parser/dow_test.go
@@ -1,0 +1,110 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseDowMatcher(t *testing.T) {
+	tests := []struct {
+		spec     string
+		time     string
+		expected bool
+	}{
+		{"*", "Thu Jan 2 2025", true},
+		{"*", "Fri Jan 3 2025", true},
+		{"?", "Thu Jan 2 2025", true},
+		{"?", "Fri Jan 3 2025", true},
+
+		{"5", "Fri Jan 3 2025", true},
+		{"2", "Wed Jan 8 2025", false},
+		{"6", "Sat Jan 4 2025", true},
+		{"Sat", "Sat Jan 4 2025", true},
+		{"SAT", "Sat Jan 4 2025", true},
+
+		{"1-3", "Mon Jan 6 2025", true},
+		{"Mon-Wed", "Mon Jan 6 2025", true},
+		{"1-3", "Sun Jan 5 2025", false},
+		{"1-3", "Tue Jan 7 2025", true},
+		{"0-2", "Wed Jan 8 2025", false},
+
+		{"1/2", "Mon Jan 6 2025", true},
+		{"1/2", "Wed Jan 8 2025", true},
+		{"1/2", "Sun Jan 5 2025", false},
+		{"*/2", "Sun Jan 5 2025", true},
+		{"*/2", "Mon Jan 6 2025", false},
+
+		{"1-4/3", "Mon Jan 6 2025", true},
+		{"1-4/3", "Thu Jan 9 2025", true},
+		{"1-4/3", "Fri Jan 10 2025", false},
+
+		{"1-4/3,5", "Fri Jan 10 2025", true},
+		{"1-4/3,6", "Fri Jan 10 2025", false},
+
+		{"1,2,3", "Mon Jan 6 2025", true},
+		{"1,2,3", "Thu Jan 9 2025", false},
+		{"1,02,3", "Tue Jan 7 2025", true},
+	}
+
+	const layout = "Mon Jan 2 2006"
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("spec=%s,now=%s", strings.Replace(test.spec, "/", "|", -1), test.time), func(t *testing.T) {
+			time, err := time.Parse(layout, test.time)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			matcher, err := ParseDow(test.spec)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			actual := matcher(time)
+			if actual != test.expected {
+				t.Fatalf("spec=%s, time=%s, expected=%t, got=%t",
+					test.spec, test.time, test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestParseDowErrors(t *testing.T) {
+	tests := []struct {
+		spec     string
+		expected string
+	}{
+		{"#", "failed to parse"},
+		{"*-5", "invalid expression"},
+		{"*-5/2", "invalid expression"},
+		{"5-*", "failed to parse"},
+		{"5-*/22", "failed to parse"},
+		{"-1", "failed to parse"},
+		{"-22", "failed to parse"},
+		{"8", "value 8 out of valid range [0, 6]"},
+		{"4-7", "value 7 out of valid range [0, 6]"},
+		{"4-7/36", "value 7 out of valid range [0, 6]"},
+		{"4-5/ABC", "failed to parse"},
+		{"*//2", "invalid expression"},
+		{"*/2/", "invalid expression"},
+		{"*-2-", "invalid expression"},
+		{"2-", "failed to parse"},
+		{"1-2-", "invalid expression"},
+	}
+
+	for _, test := range tests {
+		t.Run(strings.Replace(test.spec, "/", "|", -1), func(t *testing.T) {
+			_, err := ParseDow(test.spec)
+			if err == nil {
+				t.Fatal("expected non-nil error, got nil")
+			}
+
+			actual := err.Error()
+			if !strings.Contains(actual, test.expected) {
+				t.Fatalf("spec=%s, expectedError=%s, gotError=%s",
+					test.spec, test.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/parser/hour.go
+++ b/internal/parser/hour.go
@@ -1,0 +1,63 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gdgvda/cron/internal/matcher"
+)
+
+var hourToInt = map[string]uint{}
+
+func ParseHour(expression string) (matcher.Matcher, error) {
+	options := strings.FieldsFunc(expression, func(r rune) bool { return r == ',' })
+	matches := []matcher.Matcher{}
+	for _, option := range options {
+		match, err := parseHour(option)
+		if err != nil {
+			return nil, err
+		}
+		matches = append(matches, match)
+	}
+	return matcher.Or(matches...), nil
+}
+
+func parseHour(expression string) (matcher.Matcher, error) {
+	rangeAndStep := strings.Split(expression, "/")
+	lowAndHigh := strings.Split(rangeAndStep[0], "-")
+
+	if len(lowAndHigh) > 2 || len(rangeAndStep) > 2 {
+		return nil, fmt.Errorf("%s: invalid expression", expression)
+	}
+
+	if lowAndHigh[0] == "*" {
+		if len(lowAndHigh) > 1 {
+			return nil, fmt.Errorf("%s: invalid expression", expression)
+		}
+		lowAndHigh[0] = "0-23"
+	} else {
+		if len(lowAndHigh) == 1 && len(rangeAndStep) == 2 {
+			lowAndHigh[0] += "-23"
+		}
+	}
+
+	expression = strings.Join(lowAndHigh, "-")
+	if len(rangeAndStep) > 1 {
+		expression += "/" + rangeAndStep[1]
+	}
+
+	activations, err := span(expression, 0, 23, hourToInt)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(t time.Time) bool {
+		for _, hour := range activations {
+			if uint(t.Hour()) == hour {
+				return true
+			}
+		}
+		return false
+	}, nil
+}

--- a/internal/parser/hour_test.go
+++ b/internal/parser/hour_test.go
@@ -1,0 +1,112 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseHourMatcher(t *testing.T) {
+	tests := []struct {
+		spec     string
+		time     string
+		expected bool
+	}{
+		{"*", "21:00:21", true},
+		{"*", "23:04:59", true},
+
+		{"23", "23:00:23", true},
+		{"7", "07:17:23", true},
+		{"23", "22:00:24", false},
+
+		{"11-12", "10:00:10", false},
+		{"11-12", "11:00:15", true},
+		{"11-12", "12:00:15", true},
+		{"11-12", "13:00:17", false},
+		{"0-23", "15:17:23", true},
+
+		{"0/5", "00:00:00", true},
+		{"0/5", "05:00:15", true},
+		{"0/5", "07:00:40", false},
+		{"*/5", "00:00:00", true},
+		{"*/5", "05:00:45", true},
+		{"*/5", "07:00:40", false},
+
+		{"5/5", "05:00:15", true},
+		{"5/5", "15:00:15", true},
+		{"5/5", "20:00:23", true},
+		{"5/5", "22:03:12", false},
+
+		{"5-17/5", "05:00:15", true},
+		{"5-17/5", "10:00:20", true},
+		{"5-17/5", "20:00:50", false},
+
+		{"5-17/5,20", "20:00:50", true},
+		{"5-17/5,19", "18:00:50", false},
+
+		{"1,2,3", "00:00:00", false},
+		{"1,2,3", "02:16:02", true},
+		{"1,02,3", "02:16:02", true},
+	}
+
+	const layout = "15:04:05"
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("spec=%s,now=%s", strings.Replace(test.spec, "/", "|", -1), test.time), func(t *testing.T) {
+			time, err := time.Parse(layout, test.time)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			matcher, err := ParseHour(test.spec)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			actual := matcher(time)
+			if actual != test.expected {
+				t.Fatalf("spec=%s, time=%s, expected=%t, got=%t",
+					test.spec, test.time, test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestParseHourErrors(t *testing.T) {
+	tests := []struct {
+		spec     string
+		expected string
+	}{
+		{"#", "failed to parse"},
+		{"?", "failed to parse"},
+		{"*-5", "invalid expression"},
+		{"*-5/2", "invalid expression"},
+		{"5-*", "failed to parse"},
+		{"5-*/22", "failed to parse"},
+		{"-1", "failed to parse"},
+		{"-22", "failed to parse"},
+		{"24", "value 24 out of valid range [0, 23]"},
+		{"22-24", "value 24 out of valid range [0, 23]"},
+		{"22-25/33", "value 25 out of valid range [0, 23]"},
+		{"*//2", "invalid expression"},
+		{"*/2/", "invalid expression"},
+		{"*-2-", "invalid expression"},
+		{"2-", "failed to parse"},
+		{"1-2-", "invalid expression"},
+	}
+
+	for _, test := range tests {
+		t.Run(strings.Replace(test.spec, "/", "|", -1), func(t *testing.T) {
+			_, err := ParseHour(test.spec)
+			if err == nil {
+				t.Fatal("expected non-nil error, got nil")
+			}
+
+			actual := err.Error()
+			if !strings.Contains(actual, test.expected) {
+				t.Fatalf("spec=%s, expectedError=%s, gotError=%s",
+					test.spec, test.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/parser/minute.go
+++ b/internal/parser/minute.go
@@ -1,0 +1,63 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gdgvda/cron/internal/matcher"
+)
+
+var minuteToInt = map[string]uint{}
+
+func ParseMinute(expression string) (matcher.Matcher, error) {
+	options := strings.FieldsFunc(expression, func(r rune) bool { return r == ',' })
+	matches := []matcher.Matcher{}
+	for _, option := range options {
+		match, err := parseMinute(option)
+		if err != nil {
+			return nil, err
+		}
+		matches = append(matches, match)
+	}
+	return matcher.Or(matches...), nil
+}
+
+func parseMinute(expression string) (matcher.Matcher, error) {
+	rangeAndStep := strings.Split(expression, "/")
+	lowAndHigh := strings.Split(rangeAndStep[0], "-")
+
+	if len(lowAndHigh) > 2 || len(rangeAndStep) > 2 {
+		return nil, fmt.Errorf("%s: invalid expression", expression)
+	}
+
+	if lowAndHigh[0] == "*" {
+		if len(lowAndHigh) > 1 {
+			return nil, fmt.Errorf("%s: invalid expression", expression)
+		}
+		lowAndHigh[0] = "0-59"
+	} else {
+		if len(lowAndHigh) == 1 && len(rangeAndStep) == 2 {
+			lowAndHigh[0] += "-59"
+		}
+	}
+
+	expression = strings.Join(lowAndHigh, "-")
+	if len(rangeAndStep) > 1 {
+		expression += "/" + rangeAndStep[1]
+	}
+
+	activations, err := span(expression, 0, 59, minuteToInt)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(t time.Time) bool {
+		for _, minute := range activations {
+			if uint(t.Minute()) == minute {
+				return true
+			}
+		}
+		return false
+	}, nil
+}

--- a/internal/parser/minute_test.go
+++ b/internal/parser/minute_test.go
@@ -1,0 +1,113 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseMinuteMatcher(t *testing.T) {
+	tests := []struct {
+		spec     string
+		time     string
+		expected bool
+	}{
+		{"*", "15:21:00", true},
+		{"*", "23:59:00", true},
+
+		{"23", "15:23:00", true},
+		{"23", "15:23:17", true},
+		{"23", "15:24:00", false},
+		{"59", "23:59:00", true},
+
+		{"11-12", "15:10:00", false},
+		{"11-12", "15:11:00", true},
+		{"11-12", "15:12:00", true},
+		{"11-12", "15:13:00", false},
+		{"0-59", "15:23:17", true},
+
+		{"0/15", "15:00:00", true},
+		{"0/15", "15:45:00", true},
+		{"0/15", "15:40:00", false},
+		{"*/15", "15:00:00", true},
+		{"*/15", "15:45:00", true},
+		{"*/15", "15:40:00", false},
+
+		{"5/15", "15:05:00", true},
+		{"5/15", "15:20:00", true},
+		{"5/15", "15:50:00", true},
+		{"5/15", "15:55:00", false},
+
+		{"5-22/15", "15:05:00", true},
+		{"5-22/15", "15:20:00", true},
+		{"5-22/15", "15:50:00", false},
+		{"5-22/15", "15:55:00", false},
+
+		{"5-22/15,50", "15:50:00", true},
+		{"5-22/15,49", "15:50:00", false},
+
+		{"1,2,3", "15:00:00", false},
+		{"1,2,3", "15:02:16", true},
+	}
+
+	const layout = "15:04:05"
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("spec=%s,now=%s", strings.Replace(test.spec, "/", "|", -1), test.time), func(t *testing.T) {
+			time, err := time.Parse(layout, test.time)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			matcher, err := ParseMinute(test.spec)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			actual := matcher(time)
+			if actual != test.expected {
+				t.Fatalf("spec=%s, time=%s, expected=%t, got=%t",
+					test.spec, test.time, test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestParseMinuteErrors(t *testing.T) {
+	tests := []struct {
+		spec     string
+		expected string
+	}{
+		{"#", "failed to parse"},
+		{"?", "failed to parse"},
+		{"*-5", "invalid expression"},
+		{"*-5/2", "invalid expression"},
+		{"5-*", "failed to parse"},
+		{"5-*/22", "failed to parse"},
+		{"-1", "failed to parse"},
+		{"-22", "failed to parse"},
+		{"60", "value 60 out of valid range [0, 59]"},
+		{"22-60", "value 60 out of valid range [0, 59]"},
+		{"22-60/33", "value 60 out of valid range [0, 59]"},
+		{"*//2", "invalid expression"},
+		{"*/2/", "invalid expression"},
+		{"*-2-", "invalid expression"},
+		{"2-", "failed to parse"},
+		{"1-2-", "invalid expression"},
+	}
+
+	for _, test := range tests {
+		t.Run(strings.Replace(test.spec, "/", "|", -1), func(t *testing.T) {
+			_, err := ParseMinute(test.spec)
+			if err == nil {
+				t.Fatal("expected non-nil error, got nil")
+			}
+
+			actual := err.Error()
+			if !strings.Contains(actual, test.expected) {
+				t.Fatalf("spec=%s, expectedError=%s, gotError=%s",
+					test.spec, test.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/parser/month.go
+++ b/internal/parser/month.go
@@ -1,0 +1,76 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gdgvda/cron/internal/matcher"
+)
+
+var monthToInt = map[string]uint{
+	"jan": 1,
+	"feb": 2,
+	"mar": 3,
+	"apr": 4,
+	"may": 5,
+	"jun": 6,
+	"jul": 7,
+	"aug": 8,
+	"sep": 9,
+	"oct": 10,
+	"nov": 11,
+	"dec": 12,
+}
+
+func ParseMonth(expression string) (matcher.Matcher, error) {
+	options := strings.FieldsFunc(expression, func(r rune) bool { return r == ',' })
+	matches := []matcher.Matcher{}
+	for _, option := range options {
+		match, err := parseMonth(option)
+		if err != nil {
+			return nil, err
+		}
+		matches = append(matches, match)
+	}
+	return matcher.Or(matches...), nil
+}
+
+func parseMonth(expression string) (matcher.Matcher, error) {
+	rangeAndStep := strings.Split(expression, "/")
+	lowAndHigh := strings.Split(rangeAndStep[0], "-")
+
+	if len(lowAndHigh) > 2 || len(rangeAndStep) > 2 {
+		return nil, fmt.Errorf("%s: invalid expression", expression)
+	}
+
+	if lowAndHigh[0] == "*" {
+		if len(lowAndHigh) > 1 {
+			return nil, fmt.Errorf("%s: invalid expression", expression)
+		}
+		lowAndHigh[0] = "1-12"
+	} else {
+		if len(lowAndHigh) == 1 && len(rangeAndStep) == 2 {
+			lowAndHigh[0] += "-12"
+		}
+	}
+
+	expression = strings.Join(lowAndHigh, "-")
+	if len(rangeAndStep) > 1 {
+		expression += "/" + rangeAndStep[1]
+	}
+
+	activations, err := span(expression, 1, 12, monthToInt)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(t time.Time) bool {
+		for _, month := range activations {
+			if t.Month() == time.Month(month) {
+				return true
+			}
+		}
+		return false
+	}, nil
+}

--- a/internal/parser/month_test.go
+++ b/internal/parser/month_test.go
@@ -1,0 +1,115 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseMonthMatcher(t *testing.T) {
+	tests := []struct {
+		spec     string
+		time     string
+		expected bool
+	}{
+		{"*", "Feb 2007", true},
+		{"*", "Mar 2007", true},
+
+		{"3", "Mar 2025", true},
+		{"3", "Mar 2020", true},
+		{"3", "Feb 2020", false},
+		{"12", "Dec 2021", true},
+
+		{"10-11", "Sep 2023", false},
+		{"10-11", "Oct 2023", true},
+		{"OCT-11", "Nov 2023", true},
+		{"10-11", "Dec 2023", false},
+		{"1-12", "Dec 2023", true},
+
+		{"1/3", "Jan 2020", true},
+		{"Jan/3", "Apr 2020", true},
+		{"jAN/3", "Feb 2020", false},
+		{"*/3", "Jan 2020", true},
+		{"*/3", "Apr 2020", true},
+		{"*/3", "Feb 2020", false},
+
+		{"5/3", "May 2021", true},
+		{"5/3", "Aug 2021", true},
+		{"5/3", "Nov 2021", true},
+		{"5/3", "Jun 2021", false},
+
+		{"Feb-5/3", "Feb 2000", true},
+		{"2-5/3", "May 2000", true},
+		{"2-5/3", "Aug 2000", false},
+		{"2-5/3", "Apr 2000", false},
+
+		{"2-5/3,8", "Aug 2000", true},
+		{"2-5/3,7", "Aug 2000", false},
+
+		{"1,2,3", "Jul 2003", false},
+		{"1,2,3", "Feb 2003", true},
+		{"1,02,3", "Feb 2003", true},
+	}
+
+	const layout = "Jan 2006"
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("spec=%s,now=%s", strings.Replace(test.spec, "/", "|", -1), test.time), func(t *testing.T) {
+			time, err := time.Parse(layout, test.time)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			matcher, err := ParseMonth(test.spec)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			actual := matcher(time)
+			if actual != test.expected {
+				t.Fatalf("spec=%s, time=%s, expected=%t, got=%t",
+					test.spec, test.time, test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestParseMonthErrors(t *testing.T) {
+	tests := []struct {
+		spec     string
+		expected string
+	}{
+		{"#", "failed to parse"},
+		{"?", "failed to parse"},
+		{"*-5", "invalid expression"},
+		{"*-5/2", "invalid expression"},
+		{"5-*", "failed to parse"},
+		{"5-*/3", "failed to parse"},
+		{"-1", "failed to parse"},
+		{"-22", "failed to parse"},
+		{"0", "value 0 out of valid range [1, 12]"},
+		{"15", "value 15 out of valid range [1, 12]"},
+		{"4-13", "value 13 out of valid range [1, 12]"},
+		{"4-13/2", "value 13 out of valid range [1, 12]"},
+		{"*//2", "invalid expression"},
+		{"*/2/", "invalid expression"},
+		{"*-2-", "invalid expression"},
+		{"2-", "failed to parse"},
+		{"1-2-", "invalid expression"},
+	}
+
+	for _, test := range tests {
+		t.Run(strings.Replace(test.spec, "/", "|", -1), func(t *testing.T) {
+			_, err := ParseMonth(test.spec)
+			if err == nil {
+				t.Fatal("expected non-nil error, got nil")
+			}
+
+			actual := err.Error()
+			if !strings.Contains(actual, test.expected) {
+				t.Fatalf("spec=%s, expectedError=%s, gotError=%s",
+					test.spec, test.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/parser/second.go
+++ b/internal/parser/second.go
@@ -1,0 +1,63 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/gdgvda/cron/internal/matcher"
+)
+
+var secondToInt = map[string]uint{}
+
+func ParseSecond(expression string) (matcher.Matcher, error) {
+	options := strings.FieldsFunc(expression, func(r rune) bool { return r == ',' })
+	matches := []matcher.Matcher{}
+	for _, option := range options {
+		match, err := parseSecond(option)
+		if err != nil {
+			return nil, err
+		}
+		matches = append(matches, match)
+	}
+	return matcher.Or(matches...), nil
+}
+
+func parseSecond(expression string) (matcher.Matcher, error) {
+	rangeAndStep := strings.Split(expression, "/")
+	lowAndHigh := strings.Split(rangeAndStep[0], "-")
+
+	if len(lowAndHigh) > 2 || len(rangeAndStep) > 2 {
+		return nil, fmt.Errorf("%s: invalid expression", expression)
+	}
+
+	if lowAndHigh[0] == "*" {
+		if len(lowAndHigh) > 1 {
+			return nil, fmt.Errorf("%s: invalid expression", expression)
+		}
+		lowAndHigh[0] = "0-59"
+	} else {
+		if len(lowAndHigh) == 1 && len(rangeAndStep) == 2 {
+			lowAndHigh[0] += "-59"
+		}
+	}
+
+	expression = strings.Join(lowAndHigh, "-")
+	if len(rangeAndStep) > 1 {
+		expression += "/" + rangeAndStep[1]
+	}
+
+	activations, err := span(expression, 0, 59, secondToInt)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(t time.Time) bool {
+		for _, second := range activations {
+			if uint(t.Second()) == second {
+				return true
+			}
+		}
+		return false
+	}, nil
+}

--- a/internal/parser/second_test.go
+++ b/internal/parser/second_test.go
@@ -1,0 +1,114 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseSecondMatcher(t *testing.T) {
+	tests := []struct {
+		spec     string
+		time     string
+		expected bool
+	}{
+		{"*", "15:00:21", true},
+		{"*", "23:00:59", true},
+
+		{"23", "15:00:23", true},
+		{"23", "15:17:23", true},
+		{"23", "15:00:24", false},
+		{"59", "23:00:59", true},
+
+		{"11-12", "15:00:10", false},
+		{"11-12", "15:00:11", true},
+		{"11-12", "15:00:12", true},
+		{"11-12", "15:00:13", false},
+		{"0-59", "15:17:23", true},
+
+		{"0/15", "15:00:00", true},
+		{"0/15", "15:00:45", true},
+		{"0/15", "15:00:40", false},
+		{"*/15", "15:00:00", true},
+		{"*/15", "15:00:45", true},
+		{"*/15", "15:00:40", false},
+
+		{"5/15", "15:00:05", true},
+		{"5/15", "15:00:20", true},
+		{"5/15", "15:00:50", true},
+		{"5/15", "15:00:55", false},
+
+		{"5-22/15", "15:00:05", true},
+		{"5-22/15", "15:00:20", true},
+		{"5-22/15", "15:00:50", false},
+		{"5-22/15", "15:00:55", false},
+
+		{"5-22/15,50", "15:00:50", true},
+		{"5-22/15,49", "15:00:50", false},
+
+		{"1,2,3", "15:00:00", false},
+		{"1,2,3", "15:16:02", true},
+		{"1,02,3", "15:16:02", true},
+	}
+
+	const layout = "15:04:05"
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("spec=%s,now=%s", strings.Replace(test.spec, "/", "|", -1), test.time), func(t *testing.T) {
+			time, err := time.Parse(layout, test.time)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			matcher, err := ParseSecond(test.spec)
+			if err != nil {
+				t.Fatalf("expected nil error, got %s", err)
+			}
+
+			actual := matcher(time)
+			if actual != test.expected {
+				t.Fatalf("spec=%s, time=%s, expected=%t, got=%t",
+					test.spec, test.time, test.expected, actual)
+			}
+		})
+	}
+}
+
+func TestParseSecondErrors(t *testing.T) {
+	tests := []struct {
+		spec     string
+		expected string
+	}{
+		{"#", "failed to parse"},
+		{"?", "failed to parse"},
+		{"*-5", "invalid expression"},
+		{"*-5/2", "invalid expression"},
+		{"5-*", "failed to parse"},
+		{"5-*/22", "failed to parse"},
+		{"-1", "failed to parse"},
+		{"-22", "failed to parse"},
+		{"60", "value 60 out of valid range [0, 59]"},
+		{"22-60", "value 60 out of valid range [0, 59]"},
+		{"22-60/33", "value 60 out of valid range [0, 59]"},
+		{"*//2", "invalid expression"},
+		{"*/2/", "invalid expression"},
+		{"*-2-", "invalid expression"},
+		{"2-", "failed to parse"},
+		{"1-2-", "invalid expression"},
+	}
+
+	for _, test := range tests {
+		t.Run(strings.Replace(test.spec, "/", "|", -1), func(t *testing.T) {
+			_, err := ParseSecond(test.spec)
+			if err == nil {
+				t.Fatal("expected non-nil error, got nil")
+			}
+
+			actual := err.Error()
+			if !strings.Contains(actual, test.expected) {
+				t.Fatalf("spec=%s, expectedError=%s, gotError=%s",
+					test.spec, test.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/parser/span.go
+++ b/internal/parser/span.go
@@ -1,0 +1,85 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+func span(expression string, min, max uint, strToInt map[string]uint) ([]uint, error) {
+	rangeAndStep := strings.Split(expression, "/")
+	lowAndHigh := strings.Split(rangeAndStep[0], "-")
+
+	low, err := parseIntOrName(lowAndHigh[0], strToInt)
+	if err != nil {
+		return nil, err
+	}
+	if low < min || low > max {
+		return nil, fmt.Errorf("%s: value %d out of valid range [%d, %d]", expression, low, min, max)
+	}
+
+	var high uint
+	switch len(lowAndHigh) {
+	case 1:
+		high = low
+	case 2:
+		high, err = parseIntOrName(lowAndHigh[1], strToInt)
+		if err != nil {
+			return nil, err
+		}
+		if high < min || high > max {
+			return nil, fmt.Errorf("%s: value %d out of valid range [%d, %d]", expression, high, min, max)
+		}
+	default:
+		return nil, fmt.Errorf("too many hyphens: %s", expression)
+	}
+
+	var step uint
+	switch len(rangeAndStep) {
+	case 1:
+		step = 1
+	case 2:
+		step, err = mustParseInt(rangeAndStep[1])
+		if err != nil {
+			return nil, err
+		}
+
+		// Special handling: "N/step" means "N-max/step".
+		if len(lowAndHigh) == 1 {
+			high = max
+		}
+	default:
+		return nil, fmt.Errorf("too many slashes: %s", expression)
+	}
+
+	if step <= 0 {
+		return nil, fmt.Errorf("step should be > 0, got %d", step)
+	}
+
+	result := []uint{}
+	for i := low; i <= high; i += step {
+		result = append(result, i)
+	}
+	return result, nil
+}
+
+func parseIntOrName(expr string, names map[string]uint) (uint, error) {
+	if names != nil {
+		if namedInt, ok := names[strings.ToLower(expr)]; ok {
+			return namedInt, nil
+		}
+	}
+	return mustParseInt(expr)
+}
+
+func mustParseInt(expr string) (uint, error) {
+	num, err := strconv.Atoi(expr)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse int from %s: %s", expr, err)
+	}
+	if num < 0 {
+		return 0, fmt.Errorf("negative number (%d) not allowed: %s", num, expr)
+	}
+
+	return uint(num), nil
+}

--- a/parser.go
+++ b/parser.go
@@ -140,7 +140,7 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 		return nil, err
 	}
 
-	return &SpecSchedule{
+	return &specSchedule{
 		SecondMatch: second,
 		MinuteMatch: minute,
 		HourMatch:   hour,
@@ -259,7 +259,7 @@ func parseDescriptor(descriptor string, loc *time.Location) (Schedule, error) {
 	return nil, fmt.Errorf("unrecognized descriptor: %s", descriptor)
 }
 
-func create(second, minute, hour, dom, month, dow string, location *time.Location) (*SpecSchedule, error) {
+func create(second, minute, hour, dom, month, dow string, location *time.Location) (*specSchedule, error) {
 	secondMatch, err := parser.ParseSecond(second)
 	if err != nil {
 		return nil, err
@@ -280,7 +280,7 @@ func create(second, minute, hour, dom, month, dow string, location *time.Locatio
 	if err != nil {
 		return nil, err
 	}
-	return &SpecSchedule{
+	return &specSchedule{
 		SecondMatch: secondMatch,
 		MinuteMatch: minuteMatch,
 		HourMatch:   hourMatch,

--- a/parser.go
+++ b/parser.go
@@ -2,10 +2,10 @@ package cron
 
 import (
 	"fmt"
-	"math"
-	"strconv"
 	"strings"
 	"time"
+
+	"github.com/gdgvda/cron/internal/parser"
 )
 
 // Configuration options for creating a parser. Most options specify which
@@ -119,35 +119,34 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 		return nil, err
 	}
 
-	field := func(field string, r bounds) uint64 {
-		if err != nil {
-			return 0
-		}
-		var bits uint64
-		bits, err = getField(field, r)
-		return bits
+	second, err := parser.ParseSecond(fields[0])
+	if err != nil {
+		return nil, err
 	}
-
-	var (
-		second     = field(fields[0], seconds)
-		minute     = field(fields[1], minutes)
-		hour       = field(fields[2], hours)
-		dayofmonth = field(fields[3], dom)
-		month      = field(fields[4], months)
-		dayofweek  = field(fields[5], dow)
-	)
+	minute, err := parser.ParseMinute(fields[1])
+	if err != nil {
+		return nil, err
+	}
+	hour, err := parser.ParseHour(fields[2])
+	if err != nil {
+		return nil, err
+	}
+	day, err := parser.ParseDay(fields[3], fields[5])
+	if err != nil {
+		return nil, err
+	}
+	month, err := parser.ParseMonth(fields[4])
 	if err != nil {
 		return nil, err
 	}
 
 	return &SpecSchedule{
-		Second:   second,
-		Minute:   minute,
-		Hour:     hour,
-		Dom:      dayofmonth,
-		Month:    month,
-		Dow:      dayofweek,
-		Location: loc,
+		SecondMatch: second,
+		MinuteMatch: minute,
+		HourMatch:   hour,
+		DayMatch:    day,
+		MonthMatch:  month,
+		Location:    loc,
 	}, nil
 }
 
@@ -229,197 +228,23 @@ func ParseStandard(standardSpec string) (Schedule, error) {
 	return standardParser.Parse(standardSpec)
 }
 
-// getField returns an Int with the bits set representing all of the times that
-// the field represents or error parsing field value.  A "field" is a comma-separated
-// list of "ranges".
-func getField(field string, r bounds) (uint64, error) {
-	var bits uint64
-	ranges := strings.FieldsFunc(field, func(r rune) bool { return r == ',' })
-	for _, expr := range ranges {
-		bit, err := getRange(expr, r)
-		if err != nil {
-			return bits, err
-		}
-		bits |= bit
-	}
-	return bits, nil
-}
-
-// getRange returns the bits indicated by the given expression:
-//
-//	number | number "-" number [ "/" number ]
-//
-// or error parsing range.
-func getRange(expr string, r bounds) (uint64, error) {
-	var (
-		start, end, step uint
-		rangeAndStep     = strings.Split(expr, "/")
-		lowAndHigh       = strings.Split(rangeAndStep[0], "-")
-		singleDigit      = len(lowAndHigh) == 1
-		err              error
-	)
-
-	var extra uint64
-	if lowAndHigh[0] == "*" || lowAndHigh[0] == "?" {
-		start = r.min
-		end = r.max
-		extra = starBit
-	} else {
-		start, err = parseIntOrName(lowAndHigh[0], r.names)
-		if err != nil {
-			return 0, err
-		}
-		switch len(lowAndHigh) {
-		case 1:
-			end = start
-		case 2:
-			end, err = parseIntOrName(lowAndHigh[1], r.names)
-			if err != nil {
-				return 0, err
-			}
-		default:
-			return 0, fmt.Errorf("too many hyphens: %s", expr)
-		}
-	}
-
-	switch len(rangeAndStep) {
-	case 1:
-		step = 1
-	case 2:
-		step, err = mustParseInt(rangeAndStep[1])
-		if err != nil {
-			return 0, err
-		}
-
-		// Special handling: "N/step" means "N-max/step".
-		if singleDigit {
-			end = r.max
-		}
-		if step > 1 {
-			extra = 0
-		}
-	default:
-		return 0, fmt.Errorf("too many slashes: %s", expr)
-	}
-
-	if start < r.min {
-		return 0, fmt.Errorf("beginning of range (%d) below minimum (%d): %s", start, r.min, expr)
-	}
-	if end > r.max {
-		return 0, fmt.Errorf("end of range (%d) above maximum (%d): %s", end, r.max, expr)
-	}
-	if start > end {
-		return 0, fmt.Errorf("beginning of range (%d) beyond end of range (%d): %s", start, end, expr)
-	}
-	if step == 0 {
-		return 0, fmt.Errorf("step of range should be a positive number: %s", expr)
-	}
-
-	return getBits(start, end, step) | extra, nil
-}
-
-// parseIntOrName returns the (possibly-named) integer contained in expr.
-func parseIntOrName(expr string, names map[string]uint) (uint, error) {
-	if names != nil {
-		if namedInt, ok := names[strings.ToLower(expr)]; ok {
-			return namedInt, nil
-		}
-	}
-	return mustParseInt(expr)
-}
-
-// mustParseInt parses the given expression as an int or returns an error.
-func mustParseInt(expr string) (uint, error) {
-	num, err := strconv.Atoi(expr)
-	if err != nil {
-		return 0, fmt.Errorf("failed to parse int from %s: %s", expr, err)
-	}
-	if num < 0 {
-		return 0, fmt.Errorf("negative number (%d) not allowed: %s", num, expr)
-	}
-
-	return uint(num), nil
-}
-
-// getBits sets all bits in the range [min, max], modulo the given step size.
-func getBits(min, max, step uint) uint64 {
-	var bits uint64
-
-	// If step is 1, use shifts.
-	if step == 1 {
-		return ^(math.MaxUint64 << (max + 1)) & (math.MaxUint64 << min)
-	}
-
-	// Else, use a simple loop.
-	for i := min; i <= max; i += step {
-		bits |= 1 << i
-	}
-	return bits
-}
-
-// all returns all bits within the given bounds.  (plus the star bit)
-func all(r bounds) uint64 {
-	return getBits(r.min, r.max, 1) | starBit
-}
-
 // parseDescriptor returns a predefined schedule for the expression, or error if none matches.
 func parseDescriptor(descriptor string, loc *time.Location) (Schedule, error) {
 	switch descriptor {
 	case "@yearly", "@annually":
-		return &SpecSchedule{
-			Second:   1 << seconds.min,
-			Minute:   1 << minutes.min,
-			Hour:     1 << hours.min,
-			Dom:      1 << dom.min,
-			Month:    1 << months.min,
-			Dow:      all(dow),
-			Location: loc,
-		}, nil
+		return create("0", "0", "0", "1", "1", "*", loc)
 
 	case "@monthly":
-		return &SpecSchedule{
-			Second:   1 << seconds.min,
-			Minute:   1 << minutes.min,
-			Hour:     1 << hours.min,
-			Dom:      1 << dom.min,
-			Month:    all(months),
-			Dow:      all(dow),
-			Location: loc,
-		}, nil
+		return create("0", "0", "0", "1", "*", "*", loc)
 
 	case "@weekly":
-		return &SpecSchedule{
-			Second:   1 << seconds.min,
-			Minute:   1 << minutes.min,
-			Hour:     1 << hours.min,
-			Dom:      all(dom),
-			Month:    all(months),
-			Dow:      1 << dow.min,
-			Location: loc,
-		}, nil
+		return create("0", "0", "0", "*", "*", "0", loc)
 
 	case "@daily", "@midnight":
-		return &SpecSchedule{
-			Second:   1 << seconds.min,
-			Minute:   1 << minutes.min,
-			Hour:     1 << hours.min,
-			Dom:      all(dom),
-			Month:    all(months),
-			Dow:      all(dow),
-			Location: loc,
-		}, nil
+		return create("0", "0", "0", "*", "*", "*", loc)
 
 	case "@hourly":
-		return &SpecSchedule{
-			Second:   1 << seconds.min,
-			Minute:   1 << minutes.min,
-			Hour:     all(hours),
-			Dom:      all(dom),
-			Month:    all(months),
-			Dow:      all(dow),
-			Location: loc,
-		}, nil
-
+		return create("0", "0", "*", "*", "*", "*", loc)
 	}
 
 	const everyPrefix = "@every "
@@ -432,4 +257,35 @@ func parseDescriptor(descriptor string, loc *time.Location) (Schedule, error) {
 	}
 
 	return nil, fmt.Errorf("unrecognized descriptor: %s", descriptor)
+}
+
+func create(second, minute, hour, dom, month, dow string, location *time.Location) (*SpecSchedule, error) {
+	secondMatch, err := parser.ParseSecond(second)
+	if err != nil {
+		return nil, err
+	}
+	minuteMatch, err := parser.ParseMinute(minute)
+	if err != nil {
+		return nil, err
+	}
+	hourMatch, err := parser.ParseHour(hour)
+	if err != nil {
+		return nil, err
+	}
+	monthMatch, err := parser.ParseMonth(month)
+	if err != nil {
+		return nil, err
+	}
+	dayMatch, err := parser.ParseDay(dom, dow)
+	if err != nil {
+		return nil, err
+	}
+	return &SpecSchedule{
+		SecondMatch: secondMatch,
+		MinuteMatch: minuteMatch,
+		HourMatch:   hourMatch,
+		DayMatch:    dayMatch,
+		MonthMatch:  monthMatch,
+		Location:    location,
+	}, nil
 }

--- a/parser_test.go
+++ b/parser_test.go
@@ -9,115 +9,6 @@ import (
 
 var secondParser = NewParser(Second | Minute | Hour | Dom | Month | DowOptional | Descriptor)
 
-func TestRange(t *testing.T) {
-	zero := uint64(0)
-	ranges := []struct {
-		expr     string
-		min, max uint
-		expected uint64
-		err      string
-	}{
-		{"5", 0, 7, 1 << 5, ""},
-		{"0", 0, 7, 1 << 0, ""},
-		{"7", 0, 7, 1 << 7, ""},
-
-		{"5-5", 0, 7, 1 << 5, ""},
-		{"5-6", 0, 7, 1<<5 | 1<<6, ""},
-		{"5-7", 0, 7, 1<<5 | 1<<6 | 1<<7, ""},
-
-		{"5-6/2", 0, 7, 1 << 5, ""},
-		{"5-7/2", 0, 7, 1<<5 | 1<<7, ""},
-		{"5-7/1", 0, 7, 1<<5 | 1<<6 | 1<<7, ""},
-
-		{"*", 1, 3, 1<<1 | 1<<2 | 1<<3 | starBit, ""},
-		{"*/2", 1, 3, 1<<1 | 1<<3, ""},
-
-		{"5--5", 0, 0, zero, "too many hyphens"},
-		{"jan-x", 0, 0, zero, "failed to parse int from"},
-		{"2-x", 1, 5, zero, "failed to parse int from"},
-		{"*/-12", 0, 0, zero, "negative number"},
-		{"*//2", 0, 0, zero, "too many slashes"},
-		{"1", 3, 5, zero, "below minimum"},
-		{"6", 3, 5, zero, "above maximum"},
-		{"5-3", 3, 5, zero, "beyond end of range"},
-		{"*/0", 0, 0, zero, "should be a positive number"},
-	}
-
-	for _, c := range ranges {
-		actual, err := getRange(c.expr, bounds{c.min, c.max, nil})
-		if len(c.err) != 0 && (err == nil || !strings.Contains(err.Error(), c.err)) {
-			t.Errorf("%s => expected %v, got %v", c.expr, c.err, err)
-		}
-		if len(c.err) == 0 && err != nil {
-			t.Errorf("%s => unexpected error %v", c.expr, err)
-		}
-		if actual != c.expected {
-			t.Errorf("%s => expected %d, got %d", c.expr, c.expected, actual)
-		}
-	}
-}
-
-func TestField(t *testing.T) {
-	fields := []struct {
-		expr     string
-		min, max uint
-		expected uint64
-	}{
-		{"5", 1, 7, 1 << 5},
-		{"5,6", 1, 7, 1<<5 | 1<<6},
-		{"5,6,7", 1, 7, 1<<5 | 1<<6 | 1<<7},
-		{"1,5-7/2,3", 1, 7, 1<<1 | 1<<5 | 1<<7 | 1<<3},
-	}
-
-	for _, c := range fields {
-		actual, _ := getField(c.expr, bounds{c.min, c.max, nil})
-		if actual != c.expected {
-			t.Errorf("%s => expected %d, got %d", c.expr, c.expected, actual)
-		}
-	}
-}
-
-func TestAll(t *testing.T) {
-	allBits := []struct {
-		r        bounds
-		expected uint64
-	}{
-		{minutes, 0xfffffffffffffff}, // 0-59: 60 ones
-		{hours, 0xffffff},            // 0-23: 24 ones
-		{dom, 0xfffffffe},            // 1-31: 31 ones, 1 zero
-		{months, 0x1ffe},             // 1-12: 12 ones, 1 zero
-		{dow, 0x7f},                  // 0-6: 7 ones
-	}
-
-	for _, c := range allBits {
-		actual := all(c.r) // all() adds the starBit, so compensate for that..
-		if c.expected|starBit != actual {
-			t.Errorf("%d-%d/%d => expected %b, got %b",
-				c.r.min, c.r.max, 1, c.expected|starBit, actual)
-		}
-	}
-}
-
-func TestBits(t *testing.T) {
-	bits := []struct {
-		min, max, step uint
-		expected       uint64
-	}{
-		{0, 0, 1, 0x1},
-		{1, 1, 1, 0x2},
-		{1, 5, 2, 0x2a}, // 101010
-		{1, 4, 2, 0xa},  // 1010
-	}
-
-	for _, c := range bits {
-		actual := getBits(c.min, c.max, c.step)
-		if c.expected != actual {
-			t.Errorf("%d-%d/%d => expected %b, got %b",
-				c.min, c.max, c.step, c.expected, actual)
-		}
-	}
-}
-
 func TestParseScheduleErrors(t *testing.T) {
 	var tests = []struct{ expr, err string }{
 		{"* 5 j * * *", "failed to parse int from"},
@@ -140,68 +31,53 @@ func TestParseScheduleErrors(t *testing.T) {
 }
 
 func TestParseSchedule(t *testing.T) {
-	tokyo, _ := time.LoadLocation("Asia/Tokyo")
+	optionalSecondParser := NewParser(SecondOptional | Minute | Hour | Dom | Month | Dow | Descriptor)
+	layout := time.RFC3339
 	entries := []struct {
+		now      string
 		parser   Parser
 		expr     string
-		expected Schedule
+		expected string
 	}{
-		{secondParser, "0 5 * * * *", every5min(time.Local)},
-		{standardParser, "5 * * * *", every5min(time.Local)},
-		{secondParser, "CRON_TZ=UTC  0 5 * * * *", every5min(time.UTC)},
-		{standardParser, "CRON_TZ=UTC  5 * * * *", every5min(time.UTC)},
-		{secondParser, "CRON_TZ=Asia/Tokyo 0 5 * * * *", every5min(tokyo)},
-		{secondParser, "@every 5m", constantDelaySchedule{5 * time.Minute}},
-		{secondParser, "@midnight", midnight(time.Local)},
-		{secondParser, "TZ=UTC  @midnight", midnight(time.UTC)},
-		{secondParser, "TZ=Asia/Tokyo @midnight", midnight(tokyo)},
-		{secondParser, "@yearly", annual(time.Local)},
-		{secondParser, "@annually", annual(time.Local)},
-		{
-			parser: secondParser,
-			expr:   "* 5 * * * *",
-			expected: &SpecSchedule{
-				Second:   all(seconds),
-				Minute:   1 << 5,
-				Hour:     all(hours),
-				Dom:      all(dom),
-				Month:    all(months),
-				Dow:      all(dow),
-				Location: time.Local,
-			},
-		},
+		{"2025-01-01T18:00:00Z", secondParser, "0 5 * * * *", "2025-01-01T18:05:00Z"},
+		{"2025-01-01T18:06:00Z", secondParser, "0 5 * * * *", "2025-01-01T19:05:00Z"},
+		{"2025-01-01T18:00:00Z", standardParser, "5 * * * *", "2025-01-01T18:05:00Z"},
+		{"2025-01-01T18:00:00Z", secondParser, "CRON_TZ=UTC  0 5 * * * *", "2025-01-01T18:05:00Z"},
+		{"2025-01-01T18:00:00Z", standardParser, "CRON_TZ=UTC  5 * * * *", "2025-01-01T18:05:00Z"},
+		{"2025-01-01T18:00:00Z", secondParser, "CRON_TZ=Asia/Tokyo 0 5 * * * *", "2025-01-02T03:05:00+09:00"},
+		{"2025-01-01T18:00:00Z", secondParser, "@every 5m", "2025-01-01T18:05:00Z"},
+		{"2025-01-01T18:00:00Z", secondParser, "@midnight", "2025-01-02T00:00:00Z"},
+		{"2025-01-01T18:00:00Z", secondParser, "TZ=UTC  @midnight", "2025-01-02T00:00:00Z"},
+		{"2025-01-01T18:00:00Z", secondParser, "TZ=Asia/Tokyo @midnight", "2025-01-03T00:00:00+09:00"},
+		{"2025-01-01T18:00:00Z", secondParser, "@yearly", "2026-01-01T00:00:00Z"},
+		{"2025-01-01T18:00:00Z", secondParser, "@annually", "2026-01-01T00:00:00Z"},
+		{"2025-01-01T18:00:00Z", secondParser, "* 5 * * * *", "2025-01-01T18:05:00Z"},
+		{"2025-01-01T18:05:00Z", secondParser, "* 5 * * * *", "2025-01-01T18:05:01Z"},
+		{"2025-01-01T18:00:00Z", optionalSecondParser, "0 5 * * * *", "2025-01-01T18:05:00Z"},
+		{"2025-01-01T18:00:00Z", optionalSecondParser, "5 5 * * * *", "2025-01-01T18:05:05Z"},
+		{"2025-01-01T18:00:00Z", optionalSecondParser, "5 * * * *", "2025-01-01T18:05:00Z"},
 	}
 
 	for _, c := range entries {
-		actual, err := c.parser.Parse(c.expr)
-		if err != nil {
-			t.Errorf("%s => unexpected error %v", c.expr, err)
-		}
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("%s => expected %b, got %b", c.expr, c.expected, actual)
-		}
-	}
-}
-
-func TestOptionalSecondSchedule(t *testing.T) {
-	parser := NewParser(SecondOptional | Minute | Hour | Dom | Month | Dow | Descriptor)
-	entries := []struct {
-		expr     string
-		expected Schedule
-	}{
-		{"0 5 * * * *", every5min(time.Local)},
-		{"5 5 * * * *", every5min5s(time.Local)},
-		{"5 * * * *", every5min(time.Local)},
-	}
-
-	for _, c := range entries {
-		actual, err := parser.Parse(c.expr)
-		if err != nil {
-			t.Errorf("%s => unexpected error %v", c.expr, err)
-		}
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("%s => expected %b, got %b", c.expr, c.expected, actual)
-		}
+		t.Run(strings.Replace(c.expr, "/", "|", -1), func(t *testing.T) {
+			schedule, err := c.parser.Parse(c.expr)
+			if err != nil {
+				t.Fatalf("%s => unexpected error %v", c.expr, err)
+			}
+			now, err := time.Parse(layout, c.now)
+			if err != nil {
+				t.Fatalf("%s => unexpected error %v", c.now, err)
+			}
+			actual := schedule.Next(now).In(time.UTC)
+			expected, err := time.Parse(layout, c.expected)
+			if err != nil {
+				t.Fatalf("%s => unexpected error %v", c.expected, err)
+			}
+			expected = expected.In(time.UTC)
+			if actual != expected {
+				t.Fatalf("%s => expected %s, got %s", c.expr, expected, actual)
+			}
+		})
 	}
 }
 
@@ -315,40 +191,46 @@ func TestNormalizeFields_Errors(t *testing.T) {
 }
 
 func TestStandardSpecSchedule(t *testing.T) {
+	layout := time.RFC3339
 	entries := []struct {
+		now      string
 		expr     string
-		expected Schedule
+		expected string
 		err      string
 	}{
-		{
-			expr:     "5 * * * *",
-			expected: &SpecSchedule{1 << seconds.min, 1 << 5, all(hours), all(dom), all(months), all(dow), time.Local},
-		},
-		{
-			expr:     "@every 5m",
-			expected: constantDelaySchedule{time.Duration(5) * time.Minute},
-		},
-		{
-			expr: "5 j * * *",
-			err:  "failed to parse int from",
-		},
-		{
-			expr: "* * * *",
-			err:  "expected exactly 5 fields",
-		},
+		{"2025-01-01T18:00:00Z", "5 * * * *", "2025-01-01T18:05:00Z", ""},
+		{"2025-01-01T18:02:00Z", "@every 5m", "2025-01-01T18:07:00Z", ""},
+		{"", "5 j * * *", "", "failed to parse int from"},
+		{"", "* * * *", "", "expected exactly 5 fields"},
 	}
 
 	for _, c := range entries {
-		actual, err := ParseStandard(c.expr)
-		if len(c.err) != 0 && (err == nil || !strings.Contains(err.Error(), c.err)) {
-			t.Errorf("%s => expected %v, got %v", c.expr, c.err, err)
-		}
-		if len(c.err) == 0 && err != nil {
-			t.Errorf("%s => unexpected error %v", c.expr, err)
-		}
-		if !reflect.DeepEqual(actual, c.expected) {
-			t.Errorf("%s => expected %b, got %b", c.expr, c.expected, actual)
-		}
+		t.Run(strings.Replace(c.expr, "/", "|", -1), func(t *testing.T) {
+			schedule, err := ParseStandard(c.expr)
+			if len(c.err) != 0 && (err == nil || !strings.Contains(err.Error(), c.err)) {
+				t.Fatalf("%s => expected %v, got %v", c.expr, c.err, err)
+			}
+			if len(c.err) == 0 && err != nil {
+				t.Fatalf("%s => unexpected error %v", c.expr, err)
+			}
+
+			if err != nil {
+				return
+			}
+			now, err := time.Parse(layout, c.now)
+			if err != nil {
+				t.Fatalf("%s => unexpected error %v", c.now, err)
+			}
+			actual := schedule.Next(now).In(time.UTC)
+			expected, err := time.Parse(layout, c.expected)
+			if err != nil {
+				t.Fatalf("%s => unexpected error %v", c.expected, err)
+			}
+			expected = expected.In(time.UTC)
+			if actual != expected {
+				t.Fatalf("%s => expected %s, got %s", c.expr, expected, actual)
+			}
+		})
 	}
 }
 
@@ -357,29 +239,5 @@ func TestNoDescriptorParser(t *testing.T) {
 	_, err := parser.Parse("@every 1m")
 	if err == nil {
 		t.Error("expected an error, got none")
-	}
-}
-
-func every5min(loc *time.Location) *SpecSchedule {
-	return &SpecSchedule{1 << 0, 1 << 5, all(hours), all(dom), all(months), all(dow), loc}
-}
-
-func every5min5s(loc *time.Location) *SpecSchedule {
-	return &SpecSchedule{1 << 5, 1 << 5, all(hours), all(dom), all(months), all(dow), loc}
-}
-
-func midnight(loc *time.Location) *SpecSchedule {
-	return &SpecSchedule{1, 1, 1, all(dom), all(months), all(dow), loc}
-}
-
-func annual(loc *time.Location) *SpecSchedule {
-	return &SpecSchedule{
-		Second:   1 << seconds.min,
-		Minute:   1 << minutes.min,
-		Hour:     1 << hours.min,
-		Dom:      1 << dom.min,
-		Month:    1 << months.min,
-		Dow:      all(dow),
-		Location: loc,
 	}
 }

--- a/spec.go
+++ b/spec.go
@@ -6,9 +6,9 @@ import (
 	"github.com/gdgvda/cron/internal/matcher"
 )
 
-// SpecSchedule specifies a duty cycle (to the second granularity), based on a
+// Specifies a duty cycle (to the second granularity), based on a
 // traditional crontab specification.
-type SpecSchedule struct {
+type specSchedule struct {
 	SecondMatch, MinuteMatch, HourMatch, DayMatch, MonthMatch matcher.Matcher
 
 	// Override location for this schedule.
@@ -17,7 +17,7 @@ type SpecSchedule struct {
 
 // Next returns the next time this schedule is activated, greater than the given
 // time.  If no time can be found to satisfy the schedule, return the zero time.
-func (s *SpecSchedule) Next(t time.Time) time.Time {
+func (s *specSchedule) Next(t time.Time) time.Time {
 	// General approach
 	//
 	// For Month, Day, Hour, Minute, Second:

--- a/spec.go
+++ b/spec.go
@@ -1,57 +1,19 @@
 package cron
 
-import "time"
+import (
+	"time"
+
+	"github.com/gdgvda/cron/internal/matcher"
+)
 
 // SpecSchedule specifies a duty cycle (to the second granularity), based on a
-// traditional crontab specification. It is computed initially and stored as bit sets.
+// traditional crontab specification.
 type SpecSchedule struct {
-	Second, Minute, Hour, Dom, Month, Dow uint64
+	SecondMatch, MinuteMatch, HourMatch, DayMatch, MonthMatch matcher.Matcher
 
 	// Override location for this schedule.
 	Location *time.Location
 }
-
-// bounds provides a range of acceptable values (plus a map of name to value).
-type bounds struct {
-	min, max uint
-	names    map[string]uint
-}
-
-// The bounds for each field.
-var (
-	seconds = bounds{0, 59, nil}
-	minutes = bounds{0, 59, nil}
-	hours   = bounds{0, 23, nil}
-	dom     = bounds{1, 31, nil}
-	months  = bounds{1, 12, map[string]uint{
-		"jan": 1,
-		"feb": 2,
-		"mar": 3,
-		"apr": 4,
-		"may": 5,
-		"jun": 6,
-		"jul": 7,
-		"aug": 8,
-		"sep": 9,
-		"oct": 10,
-		"nov": 11,
-		"dec": 12,
-	}}
-	dow = bounds{0, 6, map[string]uint{
-		"sun": 0,
-		"mon": 1,
-		"tue": 2,
-		"wed": 3,
-		"thu": 4,
-		"fri": 5,
-		"sat": 6,
-	}}
-)
-
-const (
-	// Set the top bit if a star was included in the expression.
-	starBit = 1 << 63
-)
 
 // Next returns the next time this schedule is activated, greater than the given
 // time.  If no time can be found to satisfy the schedule, return the zero time.
@@ -94,7 +56,7 @@ WRAP:
 
 	// Find the first applicable month.
 	// If it's this month, then do nothing.
-	for 1<<uint(t.Month())&s.Month == 0 {
+	for !s.MonthMatch(t) {
 		// If we have to add a month, reset the other parts to 0.
 		if !added {
 			added = true
@@ -114,7 +76,7 @@ WRAP:
 	// NOTE: This causes issues for daylight savings regimes where midnight does
 	// not exist.  For example: Sao Paulo has DST that transforms midnight on
 	// 11/3 into 1am. Handle that by noticing when the Hour ends up != 0.
-	for !dayMatches(s, t) {
+	for !s.DayMatch(t) {
 		if !added {
 			added = true
 			t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc)
@@ -135,7 +97,7 @@ WRAP:
 		}
 	}
 
-	for 1<<uint(t.Hour())&s.Hour == 0 {
+	for !s.HourMatch(t) {
 		if !added {
 			added = true
 			t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, loc)
@@ -147,7 +109,7 @@ WRAP:
 		}
 	}
 
-	for 1<<uint(t.Minute())&s.Minute == 0 {
+	for !s.MinuteMatch(t) {
 		if !added {
 			added = true
 			t = t.Truncate(time.Minute)
@@ -159,7 +121,7 @@ WRAP:
 		}
 	}
 
-	for 1<<uint(t.Second())&s.Second == 0 {
+	for !s.SecondMatch(t) {
 		if !added {
 			added = true
 			t = t.Truncate(time.Second)
@@ -172,17 +134,4 @@ WRAP:
 	}
 
 	return t.In(origLocation)
-}
-
-// dayMatches returns true if the schedule's day-of-week and day-of-month
-// restrictions are satisfied by the given time.
-func dayMatches(s *SpecSchedule, t time.Time) bool {
-	var (
-		domMatch bool = 1<<uint(t.Day())&s.Dom > 0
-		dowMatch bool = 1<<uint(t.Weekday())&s.Dow > 0
-	)
-	if s.Dom&starBit > 0 || s.Dow&starBit > 0 {
-		return domMatch && dowMatch
-	}
-	return domMatch || dowMatch
 }


### PR DESCRIPTION
- Replaced bitset configs with matching functions in order to simplify activation logic definition
- Made SpecSchedule private