### PR TITLE
fix: return errors instead of panics or unexpected behaviour.

### DIFF
--- a/internal/parser/dom.go
+++ b/internal/parser/dom.go
@@ -11,7 +11,10 @@ import (
 var domToInt = map[string]uint{}
 
 func ParseDom(expression string) (matcher.Matcher, error) {
-	options := strings.FieldsFunc(expression, func(r rune) bool { return r == ',' })
+	options, err := splitOptions(expression)
+	if err != nil {
+		return nil, err
+	}
 	matches := []matcher.Matcher{}
 	for _, option := range options {
 		match, err := parseDom(option)
@@ -42,6 +45,9 @@ func parseDom(expression string) (matcher.Matcher, error) {
 			offset, err = mustParseInt(lowAndHigh[1])
 			if err != nil {
 				return nil, err
+			}
+			if offset > 30 {
+				return nil, fmt.Errorf("%s: invalid amount of days subtracted", expression)
 			}
 		}
 		return func(t time.Time) bool {

--- a/internal/parser/dow.go
+++ b/internal/parser/dow.go
@@ -19,7 +19,10 @@ var dowToInt = map[string]uint{
 }
 
 func ParseDow(expression string) (matcher.Matcher, error) {
-	options := strings.FieldsFunc(expression, func(r rune) bool { return r == ',' })
+	options, err := splitOptions(expression)
+	if err != nil {
+		return nil, err
+	}
 	matches := []matcher.Matcher{}
 	for _, option := range options {
 		match, err := parseDow(option)

--- a/internal/parser/hour.go
+++ b/internal/parser/hour.go
@@ -11,7 +11,10 @@ import (
 var hourToInt = map[string]uint{}
 
 func ParseHour(expression string) (matcher.Matcher, error) {
-	options := strings.FieldsFunc(expression, func(r rune) bool { return r == ',' })
+	options, err := splitOptions(expression)
+	if err != nil {
+		return nil, err
+	}
 	matches := []matcher.Matcher{}
 	for _, option := range options {
 		match, err := parseHour(option)

--- a/internal/parser/minute.go
+++ b/internal/parser/minute.go
@@ -11,7 +11,10 @@ import (
 var minuteToInt = map[string]uint{}
 
 func ParseMinute(expression string) (matcher.Matcher, error) {
-	options := strings.FieldsFunc(expression, func(r rune) bool { return r == ',' })
+	options, err := splitOptions(expression)
+	if err != nil {
+		return nil, err
+	}
 	matches := []matcher.Matcher{}
 	for _, option := range options {
 		match, err := parseMinute(option)

--- a/internal/parser/month.go
+++ b/internal/parser/month.go
@@ -24,7 +24,10 @@ var monthToInt = map[string]uint{
 }
 
 func ParseMonth(expression string) (matcher.Matcher, error) {
-	options := strings.FieldsFunc(expression, func(r rune) bool { return r == ',' })
+	options, err := splitOptions(expression)
+	if err != nil {
+		return nil, err
+	}
 	matches := []matcher.Matcher{}
 	for _, option := range options {
 		match, err := parseMonth(option)

--- a/internal/parser/options.go
+++ b/internal/parser/options.go
@@ -1,0 +1,14 @@
+package parser
+
+import (
+	"fmt"
+	"strings"
+)
+
+func splitOptions(expression string) ([]string, error) {
+	options := strings.FieldsFunc(expression, func(r rune) bool { return r == ',' })
+	if len(options) == 0 {
+		return nil, fmt.Errorf("invalid expression: empty list")
+	}
+	return options, nil
+}

--- a/internal/parser/second.go
+++ b/internal/parser/second.go
@@ -11,7 +11,10 @@ import (
 var secondToInt = map[string]uint{}
 
 func ParseSecond(expression string) (matcher.Matcher, error) {
-	options := strings.FieldsFunc(expression, func(r rune) bool { return r == ',' })
+	options, err := splitOptions(expression)
+	if err != nil {
+		return nil, err
+	}
 	matches := []matcher.Matcher{}
 	for _, option := range options {
 		match, err := parseSecond(option)

--- a/internal/parser/span.go
+++ b/internal/parser/span.go
@@ -30,6 +30,9 @@ func span(expression string, min, max uint, strToInt map[string]uint) ([]uint, e
 		if high < min || high > max {
 			return nil, fmt.Errorf("%s: value %d out of valid range [%d, %d]", expression, high, min, max)
 		}
+		if high < low {
+			return nil, fmt.Errorf("%s: beginning of range (%d) beyond end of range (%d)", expression, low, high)
+		}
 	default:
 		return nil, fmt.Errorf("too many hyphens: %s", expression)
 	}

--- a/parser.go
+++ b/parser.go
@@ -94,6 +94,9 @@ func (p Parser) Parse(spec string) (Schedule, error) {
 	if strings.HasPrefix(spec, "TZ=") || strings.HasPrefix(spec, "CRON_TZ=") {
 		var err error
 		i := strings.Index(spec, " ")
+		if i == -1 {
+			return nil, fmt.Errorf("invalid location descriptior: %s", spec)
+		}
 		eq := strings.Index(spec, "=")
 		if loc, err = time.LoadLocation(spec[eq+1 : i]); err != nil {
 			return nil, fmt.Errorf("provided bad location %s: %v", spec[eq+1:i], err)

--- a/parser_test.go
+++ b/parser_test.go
@@ -5,9 +5,11 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode"
 )
 
 var secondParser = NewParser(Second | Minute | Hour | Dom | Month | DowOptional | Descriptor)
+var optionalSecondParser = NewParser(SecondOptional | Minute | Hour | Dom | Month | Dow | Descriptor)
 
 func TestParseScheduleErrors(t *testing.T) {
 	var tests = []struct{ expr, err string }{
@@ -21,6 +23,7 @@ func TestParseScheduleErrors(t *testing.T) {
 		{"* * * * L", "failed to parse"},
 		{"* * * L/2 *", "L/2: invalid expression"},
 		{"* * * L-4/2 *", "L-4/2: invalid expression"},
+		{"* * * L-31 *", "L-31: invalid amount of days subtracted"},
 	}
 	for _, c := range tests {
 		t.Run(strings.Replace(c.expr, "/", "|", -1), func(t *testing.T) {
@@ -36,7 +39,6 @@ func TestParseScheduleErrors(t *testing.T) {
 }
 
 func TestParseSchedule(t *testing.T) {
-	optionalSecondParser := NewParser(SecondOptional | Minute | Hour | Dom | Month | Dow | Descriptor)
 	layout := time.RFC3339
 	entries := []struct {
 		now      string
@@ -207,6 +209,14 @@ func TestStandardSpecSchedule(t *testing.T) {
 		{"2025-01-01T18:02:00Z", "@every 5m", "2025-01-01T18:07:00Z", ""},
 		{"", "5 j * * *", "", "failed to parse int from"},
 		{"", "* * * *", "", "expected exactly 5 fields"},
+		{"", "TZ=", "", "invalid location descriptior: TZ="},
+		{"", "CRON_TZ=0", "", "invalid location descriptior: CRON_TZ=0"},
+		{"", ", 0 1 1 0", "", "invalid expression: empty list"},
+		{"", "0 , 1 1 0", "", "invalid expression: empty list"},
+		{"", "0 1 , 1 0", "", "invalid expression: empty list"},
+		{"", "0 2 1 , 0", "", "invalid expression: empty list"},
+		{"", "0 3 1 1 ,", "", "invalid expression: empty list"},
+		{"", "0 0 * 1 1-0", "", "beginning of range (1) beyond end of range (0)"},
 	}
 
 	for _, c := range entries {
@@ -244,5 +254,154 @@ func TestNoDescriptorParser(t *testing.T) {
 	_, err := parser.Parse("@every 1m")
 	if err == nil {
 		t.Error("expected an error, got none")
+	}
+}
+
+// can be started like `go test -fuzz=FuzzParser` and will run until a failure is found or manually stopped
+func FuzzParser(f *testing.F) {
+	testcases := []string{
+		"* * * * *",
+		"* * * * * *",
+		"5 * * * *",
+		"0 22 * * 1-5",
+		"23 0-20/2 * * *",
+		"5 4 * * sun",
+		"0 0,12 1 */2 *",
+		"* * L * *",
+		"* * L-28 2 *",
+		"* * 29 FEB *",
+		"* * 29 jan,FEB,mar,apr,may,JUN,jUl,aug,sep,oct,nov,dec *",
+		"1 2 3 4 mon,tue,wed,thu,fri,sat,sun",
+		"CRON_TZ=UTC  0 5 * * * *",
+		"0 0 1,2,3,5,8,13,21 AUG 3",
+		"1-2 3-4 5-6 JUL-sep tUe-FrI",
+		"@every 5m",
+		"@midnight",
+		"@weekly",
+		"TZ=UTC  @midnight",
+		"TZ=Asia/Tokyo @midnight",
+		"@yearly",
+		"@annually",
+	}
+	for _, v := range testcases {
+		f.Add(v)
+	}
+	f.Fuzz(func(t *testing.T, schedule string) {
+		parsed, errStd := ParseStandard(schedule)
+		if errStd == nil {
+			sanityCheck(t, parsed, schedule, "standard parser")
+		}
+		parsed, errSec := secondParser.Parse(schedule)
+		if errSec == nil {
+			sanityCheck(t, parsed, schedule, "second parser")
+		}
+		parsed, errOpt := optionalSecondParser.Parse(schedule)
+		if errOpt == nil {
+			sanityCheck(t, parsed, schedule, "optional second parser")
+		}
+	})
+}
+
+func sanityCheck(t *testing.T, parsed Schedule, schedule, name string) {
+	looksLikeCron(t, schedule, name)
+	day, month := getDate(schedule, name)
+	if !mightNotExist(day, month) {
+		willBeScheduled(t, parsed, schedule, name)
+	}
+}
+
+func getDate(schedule string, name string) (string, string) {
+	fields := getNonTzFields(schedule)
+	if len(fields) < 5 {
+		return "", ""
+	}
+	if name == "standard parser" {
+		return fields[2], fields[3]
+	} else if name == "second parser" {
+		return fields[3], fields[4]
+	} else if name == "optional second parser" {
+		if len(fields) == 6 {
+			return fields[3], fields[4]
+		} else {
+			return fields[2], fields[3]
+		}
+	}
+	return "", ""
+}
+
+// mightNotExist filters a supersets of dates that don't exist
+func mightNotExist(day, month string) bool {
+	return contains(month, day, "2", "feb", "30", "31", "L-30", "L-29") ||
+		contains(month, day, "4", "apr", "31", "L-31") ||
+		contains(month, day, "6", "jun", "31", "L-31") ||
+		contains(month, day, "9", "sep", "31", "L-30") ||
+		contains(month, day, "11", "nov", "31", "L-30")
+}
+
+func contains(month, day string, monthNum, monthName string, daysTest ...string) bool {
+	if !strings.Contains(month, monthNum) && !strings.Contains(strings.ToLower(month), monthName) {
+		return false
+	}
+	for _, d := range daysTest {
+		if strings.Contains(day, d) {
+			return true
+		}
+	}
+	return false
+}
+
+// looksLikeCron checks if the schedule roughly matches expected cron syntax
+func looksLikeCron(t *testing.T, schedule, name string) {
+	fields := getNonTzFields(schedule)
+	if len(fields) == 0 {
+		t.Errorf("empty schedule")
+	}
+	if strings.HasPrefix(fields[0], "@every") {
+		if !(len(fields) == 2) {
+			t.Errorf("%s %s: expected 2 fields, got %d", name, schedule, len(fields))
+		}
+	} else if strings.HasPrefix(fields[0], "@") {
+		if !(len(fields) == 1) {
+			t.Errorf("%s %s: expected 1 field, got %d", name, schedule, len(fields))
+		}
+	} else {
+		if !(len(fields) == 5 || len(fields) == 6) {
+			t.Errorf("%s %s: expected 5 or 6 fields, got %d", name, schedule, len(fields))
+		}
+		validateChars(t, fields, name)
+	}
+}
+
+func getNonTzFields(schedule string) []string {
+	schedule = strings.TrimSpace(schedule)
+	fields := strings.Fields(schedule)
+	if strings.HasPrefix(fields[0], "TZ=") || strings.HasPrefix(fields[0], "CRON_TZ=") {
+		fields = fields[1:]
+	}
+	return fields
+}
+
+func validateChars(t *testing.T, fields []string, name string) {
+	for _, field := range fields {
+		for _, c := range field {
+			if !strings.ContainsRune("0123456789+*-,/?sunmotewdhfriajbpylgcv", unicode.ToLower(c)) {
+				t.Errorf("unexpected character %c in %s for %s", c, fields, name)
+			}
+		}
+	}
+}
+
+var startTimes = []time.Time{
+	time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	time.Date(2024, 12, 13, 23, 59, 59, 0, time.UTC),
+	time.Date(2000, 2, 28, 13, 21, 30, 0, time.UTC),
+}
+
+func willBeScheduled(t *testing.T, parsed Schedule, schedule string, name string) {
+	for _, startTime := range startTimes {
+		next := parsed.Next(startTime)
+		if !next.After(startTime) {
+			t.Errorf("%s failed for '%s': expected next time to be after %v, got %v", name, schedule, startTime, next)
+		}
 	}
 }

--- a/spec_test.go
+++ b/spec_test.go
@@ -60,6 +60,7 @@ func TestActivation(t *testing.T) {
 		{"Sun Jul 15 00:00 2012", "* * L * *", false},
 		{"Tue Jul 31 00:00 2012", "* * L * *", true},
 		{"Tue Jul 31 00:00 2012", "* * L * Mon", true},
+		{"Tue Feb 1 00:00 2012", "* * L-28 2 *", true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Hi everyone,

I thought I'd try to write a fuzzer for the parser. It isn't as elegant as I hoped it to be, crontabs are kind of more complicated than you'd think :)
Anyway, it found a couple of minor things. The first two even seem to exist in the original robfig repo:

- fixes a panic for strings that start with a time zone and have no space char at all
- introduces errors for lists that consist of nothing but a ',' char
- restores errors for reversed ranges like '5-2'
- prevents the creation of dom subtractions that won't ever match a real date (e.g. L-35)

hope you like it :)