### PR TITLE
Supports `FnTimeNow`, use precise time calculated by the user to avoid system time deviations

### DIFF
--- a/chain.go
+++ b/chain.go
@@ -66,7 +66,7 @@ func DelayIfStillRunning(logger *slog.Logger) JobWrapper {
 	return func(job func()) func() {
 		var mu sync.Mutex
 		return func() {
-			start := time.Now()
+			start := GetTimeNow()
 			mu.Lock()
 			defer mu.Unlock()
 			if dur := time.Since(start); dur > time.Minute {

--- a/cron.go
+++ b/cron.go
@@ -273,7 +273,7 @@ func (c *Cron) startJob(job func()) {
 
 // now returns current time in c location
 func (c *Cron) now() time.Time {
-	return time.Now().In(c.location)
+	return GetTimeNow().In(c.location)
 }
 
 // Stop stops the cron scheduler if it is running; otherwise it does nothing.
@@ -310,4 +310,19 @@ func (c *Cron) removeEntry(id ID) {
 			return
 		}
 	}
+}
+
+// FnTimeNow allows overriding the time source used by the cron scheduler.
+// When set to a non-nil function, it will be called instead of time.Now().
+// This is useful for testing or to provide a custom time source to avoid
+// system time deviations.
+var FnTimeNow func() time.Time
+
+// GetTimeNow returns the current time using the configured time source.
+// If FnTimeNow is set, it uses that function; otherwise it falls back to time.Now().
+func GetTimeNow() time.Time {
+	if FnTimeNow != nil {
+		return FnTimeNow()
+	}
+	return time.Now()
 }


### PR DESCRIPTION
I hope cron can support user calculated time.Now

For example, my local system time is 20 seconds behind standard UTC time. For the cron expression "0 * * * * *", the first is the number of seconds, which should be triggered every minute at 0 seconds. However, due to the error in the local system time, the trigger will be delayed by 20 seconds.

I have calculated the local time offset through ntp and obtained the precise current time. If cron can support the use of custom current time, the task function can be triggered at the precise time.

I know that it can also be solved by calling the system API to correct the system time, but modifying the system time usually requires special processing for specific systems and usually requires administrator privileges, which increases the cost of users;

If precise time is used in the cron library, any system can be supported.

```go
	c := cron.New(cron.WithSeconds())
	c.AddFunc("0 * * * * *", func() {
		realTime := btime.UTCStamp()      // correct utc timestamp
		sysTime := time.Now().UnixMilli() // local system timestamp
		fmt.Printf("system: %d, real: %d\n", sysTime, realTime)
	})
	c.Start()
	time.Sleep(time.Minute * 3)
```
output: 
```text
system: 1748951280005, real: 1748951300035
system: 1748951340000, real: 1748951360035
system: 1748951400000, real: 1748951420035
```