### PR TITLE
feat(parser): replace ParseStandard() with StandardOptions

### DIFF
--- a/cron_test.go
+++ b/cron_test.go
@@ -211,7 +211,7 @@ func TestSnapshotEntries(t *testing.T) {
 	executed := false
 	clock := NewTimerSkippingInstantExecutionClock(start)
 	cron := New(WithClock(clock))
-	sched, err := ParseStandard("@every 2s")
+	sched, err := standardParser.Parse("@every 2s")
 	if err != nil {
 		t.Error("non-nil error")
 	}
@@ -876,7 +876,7 @@ func TestRunningOutOfIDs(t *testing.T) {
 	cron := New()
 	cron.next = ID(^uint(0))
 
-	sched, err := ParseStandard("* * * * *")
+	sched, err := standardParser.Parse("* * * * *")
 	if err != nil {
 		t.Error("non-nil error")
 	}

--- a/doc.go
+++ b/doc.go
@@ -17,16 +17,17 @@ Callers may register funcs to be invoked on a given schedule. Cron will run
 them in their own goroutines.
 
 	c := cron.New()
+	parser, _ := cron.NewDefaultParser(cron.StandardOptions)
 
-	sched, _ := cron.ParseStandard("30 * * * *")
+	sched, _ := parser.Parse("30 * * * *")
 	c.Schedule(sched, func() { fmt.Println("Every hour on the half hour") })
-	sched, _ = cron.ParseStandard("30 3-6,20-23 * * *")
+	sched, _ = parser.Parse("30 3-6,20-23 * * *")
 	c.Schedule(sched, func() { fmt.Println(".. in the range 3-6am, 8-11pm") })
-	sched, _ = cron.ParseStandard("CRON_TZ=Asia/Tokyo 30 04 * * *")
+	sched, _ = parser.Parse("CRON_TZ=Asia/Tokyo 30 04 * * *")
 	c.Schedule(sched, func() { fmt.Println("Runs at 04:30 Tokyo time every day") })
-	sched, _ = cron.ParseStandard("@hourly")
+	sched, _ = parser.Parse("@hourly")
 	c.Schedule(sched, func() { fmt.Println("Every hour, starting an hour from now") })
-	sched, _ = cron.ParseStandard("@every 1h30m")
+	sched, _ = parser.Parse("@every 1h30m")
 	c.Schedule(sched, func() { fmt.Println("Every hour thirty, starting an hour thirty from now") })
 
 	c.Start()
@@ -34,7 +35,7 @@ them in their own goroutines.
 	// Funcs are invoked in their own goroutine, asynchronously.
 	...
 	// Funcs may also be added to a running Cron
-	sched, _ = cron.ParseStandard("@daily")
+	sched, _ = parser.Parse("@daily")
 	c.Schedule(sched, func() { fmt.Println("Every day") })
 	..
 	// Inspect the cron job entries' next and previous run times.
@@ -184,17 +185,18 @@ of the cron spec, of the form "CRON_TZ=Asia/Tokyo".
 For example:
 
 	# Runs at 6am in time.Local
-	sched, _ := cron.ParseStandard("0 6 * * ?")
+	parser, _ := cron.NewDefaultParser(cron.StandardOptions)
+	sched, _ := parser.Parse("0 6 * * ?")
 	cron.New().Schedule(sched, ...)
 
 	# Runs at 6am in America/New_York
 	nyc, _ := time.LoadLocation("America/New_York")
 	c := cron.New(cron.WithClock(cron.NewDefaultClock(nyc, cron.DefaultNopTimer)))
-	sched, _ = cron.ParseStandard("0 6 * * ?")
+	sched, _ = parser.Parse("0 6 * * ?")
 	c.Schedule(sched, ...)
 
 	# Runs at 6am in Asia/Tokyo
-	sched, _ = cron.ParseStandard("CRON_TZ=Asia/Tokyo 0 6 * * ?")
+	sched, _ = parser.Parse("CRON_TZ=Asia/Tokyo 0 6 * * ?")
 	cron.New().Schedule(sched, ...)
 
 The prefix "TZ=(TIME ZONE)" is also supported for legacy compatibility.

--- a/option_test.go
+++ b/option_test.go
@@ -23,7 +23,7 @@ func TestWithVerboseLogger(t *testing.T) {
 		t.Error("expected provided logger")
 	}
 
-	sched, err := ParseStandard("@every 1s")
+	sched, err := standardParser.Parse("@every 1s")
 	if err != nil {
 		t.Error("non-nil error")
 	}
@@ -51,7 +51,7 @@ func TestWithOnCycleCompleted(t *testing.T) {
 	}
 	c := New(WithOnCycleCompleted(f))
 
-	sched, err := ParseStandard("@every 1s")
+	sched, err := standardParser.Parse("@every 1s")
 	if err != nil {
 		t.Error("non-nil error")
 	}

--- a/parser.go
+++ b/parser.go
@@ -26,6 +26,10 @@ const (
 	Descriptor                             // Allow descriptors such as @monthly, @weekly, etc.
 )
 
+// StandardOptions represents the default options for parsing standard cron strings.
+// It includes 5 fields (Minute, Hour, Dom, Month, Dow) and the Descriptor option.
+const StandardOptions = Minute | Hour | Dom | Month | Dow | Descriptor
+
 var places = []ParseOption{
 	Second,
 	Minute,
@@ -213,22 +217,6 @@ func normalizeFields(fields []string, options ParseOption) ([]string, error) {
 		}
 	}
 	return expandedFields, nil
-}
-
-var standardParser, _ = NewDefaultParser(
-	Minute | Hour | Dom | Month | Dow | Descriptor,
-)
-
-// ParseStandard returns a new crontab schedule representing the given
-// standardSpec (https://en.wikipedia.org/wiki/Cron). It requires 5 entries
-// representing: minute, hour, day of month, month and day of week, in that
-// order. It returns a descriptive error if the spec is not valid.
-//
-// It accepts
-//   - Standard crontab specs, e.g. "* * * * ?"
-//   - Descriptors, e.g. "@midnight", "@every 1h30m"
-func ParseStandard(standardSpec string) (Schedule, error) {
-	return standardParser.Parse(standardSpec)
 }
 
 // parseDescriptor returns a predefined schedule for the expression, or error if none matches.

--- a/parser_test.go
+++ b/parser_test.go
@@ -10,6 +10,7 @@ import (
 
 var secondParser, _ = NewDefaultParser(Second | Minute | Hour | Dom | Month | DowOptional | Descriptor)
 var optionalSecondParser, _ = NewDefaultParser(SecondOptional | Minute | Hour | Dom | Month | Dow | Descriptor)
+var standardParser, _ = NewDefaultParser(StandardOptions)
 
 func TestParseScheduleErrors(t *testing.T) {
 	var tests = []struct{ expr, err string }{
@@ -221,7 +222,7 @@ func TestStandardSpecSchedule(t *testing.T) {
 
 	for _, c := range entries {
 		t.Run(strings.Replace(c.expr, "/", "|", -1), func(t *testing.T) {
-			schedule, err := ParseStandard(c.expr)
+			schedule, err := standardParser.Parse(c.expr)
 			if len(c.err) != 0 && (err == nil || !strings.Contains(err.Error(), c.err)) {
 				t.Fatalf("%s => expected %v, got %v", c.expr, c.err, err)
 			}
@@ -361,7 +362,7 @@ func FuzzParser(f *testing.F) {
 		f.Add(v)
 	}
 	f.Fuzz(func(t *testing.T, schedule string) {
-		parsed, errStd := ParseStandard(schedule)
+		parsed, errStd := standardParser.Parse(schedule)
 		if errStd == nil {
 			sanityCheck(t, parsed, schedule, "standard parser")
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 var secondParser, _ = NewDefaultParser(Second | Minute | Hour | Dom | Month | DowOptional | Descriptor)
-var optionalSecondParser, _ = NewDefaultParser(SecondOptional | Minute | Hour | Dom | Month | Dow | Descriptor)
+var optionalSecondParser, _ = NewDefaultParser(SecondOptional | StandardOptions)
 var standardParser, _ = NewDefaultParser(StandardOptions)
 
 func TestParseScheduleErrors(t *testing.T) {

--- a/schedule_test.go
+++ b/schedule_test.go
@@ -65,7 +65,7 @@ func TestActivation(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(fmt.Sprintf("now=%s,spec=%s", test.time, strings.Replace(test.spec, "/", "|", -1)), func(t *testing.T) {
-			sched, err := ParseStandard(test.spec)
+			sched, err := standardParser.Parse(test.spec)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -228,7 +228,7 @@ func TestErrors(t *testing.T) {
 	}
 	for _, spec := range invalidSpecs {
 		t.Run(strings.Replace(spec, "/", "|", -1), func(t *testing.T) {
-			_, err := ParseStandard(spec)
+			_, err := standardParser.Parse(spec)
 			if err == nil {
 				t.Fatal("expected an error parsing: ", spec)
 			}
@@ -282,7 +282,7 @@ func TestNextWithTz(t *testing.T) {
 	}
 	for _, c := range runs {
 		t.Run(fmt.Sprintf("now=%s,spec=%s", c.time, strings.Replace(c.spec, "/", "|", -1)), func(t *testing.T) {
-			sched, err := ParseStandard(c.spec)
+			sched, err := standardParser.Parse(c.spec)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -316,7 +316,7 @@ func getTimeTZ(value string) time.Time {
 // https://github.com/robfig/cron/issues/144
 func TestSlash0NoHang(t *testing.T) {
 	schedule := "TZ=America/New_York 15/0 * * * *"
-	_, err := ParseStandard(schedule)
+	_, err := standardParser.Parse(schedule)
 	if err == nil {
 		t.Fatal("expected an error on 0 increment")
 	}


### PR DESCRIPTION
* Removed the standalone `ParseStandard` convenience function and the internal `standardParser` variable from `parser.go`.
* Added a new exported constant `StandardOptions` that encapsulates the default standard cron parsing options (`Minute | Hour | Dom | Month | Dow | Descriptor`).
* Revised `doc.go` to demonstrate the new recommended pattern: instantiating a default parser using `cron.NewDefaultParser(cron.StandardOptions)` and calling `Parse()` on it.
* Updated test files to initialize their own standard parser instances where needed, replacing the old `ParseStandard` calls.