### PR TITLE
fix(clock): DefaultClock.stop() deadlocks after an unobserved fire

### DIFF
--- a/default_clock.go
+++ b/default_clock.go
@@ -1,6 +1,9 @@
 package cron
 
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 const DefaultNopTimer = 100_000 * time.Hour
 
@@ -34,16 +37,15 @@ func (c *DefaultClock) NopTimer() (<-chan struct{}, func()) {
 
 func (c *DefaultClock) timer(duration time.Duration) (<-chan struct{}, func()) {
 	timer := time.NewTimer(duration)
-	out := make(chan struct{})
+	out := make(chan struct{}, 1)
 	stop := make(chan struct{})
 	go func() {
+		defer timer.Stop()
 		select {
 		case <-timer.C:
 			out <- struct{}{}
 		case <-stop:
 		}
 	}()
-	return out, func() {
-		stop <- struct{}{}
-	}
+	return out, sync.OnceFunc(func() { close(stop) })
 }

--- a/default_clock_test.go
+++ b/default_clock_test.go
@@ -1,0 +1,40 @@
+package cron
+
+import (
+	"testing"
+	"time"
+)
+
+// The scheduler calls stop() whenever it wakes for a reason other than the timer. That can happen
+// after the timer has already fired, with nobody left to receive the activation: stop() must still
+// return, or the scheduler goroutine deadlocks.
+func TestDefaultClockStopDoesNotBlock(t *testing.T) {
+	cases := []struct {
+		name   string
+		settle time.Duration
+	}{
+		{"before the timer fires", 0},
+		{"after the timer fired unobserved", 50 * time.Millisecond},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			clock := NewDefaultClock(time.UTC, DefaultNopTimer)
+			_, stop := clock.Timer(clock.Now().Add(5 * time.Millisecond))
+
+			time.Sleep(c.settle)
+
+			done := make(chan struct{})
+			go func() {
+				stop()
+				close(done)
+			}()
+
+			select {
+			case <-done:
+			case <-time.After(2 * time.Second):
+				t.Fatal("stop() blocked forever")
+			}
+		})
+	}
+}

--- a/default_clock_test.go
+++ b/default_clock_test.go
@@ -5,9 +5,21 @@ import (
 	"time"
 )
 
-// The scheduler calls stop() whenever it wakes for a reason other than the timer. That can happen
-// after the timer has already fired, with nobody left to receive the activation: stop() must still
-// return, or the scheduler goroutine deadlocks.
+// stopCompletesWithin isolates stop in its own goroutine, so a deadlock fails the test instead of the package.
+func stopCompletesWithin(t *testing.T, stop func(), timeout time.Duration) {
+	t.Helper()
+	done := make(chan struct{})
+	go func() {
+		stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		t.Fatal("stop() blocked forever")
+	}
+}
+
 func TestDefaultClockStopDoesNotBlock(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -24,17 +36,15 @@ func TestDefaultClockStopDoesNotBlock(t *testing.T) {
 
 			time.Sleep(c.settle)
 
-			done := make(chan struct{})
-			go func() {
-				stop()
-				close(done)
-			}()
-
-			select {
-			case <-done:
-			case <-time.After(2 * time.Second):
-				t.Fatal("stop() blocked forever")
-			}
+			stopCompletesWithin(t, stop, 2*time.Second)
 		})
 	}
+}
+
+func TestDefaultClockStopIsIdempotent(t *testing.T) {
+	clock := NewDefaultClock(time.UTC, DefaultNopTimer)
+	_, stop := clock.Timer(clock.Now().Add(time.Hour))
+
+	stopCompletesWithin(t, stop, 2*time.Second)
+	stopCompletesWithin(t, stop, 2*time.Second)
 }


### PR DESCRIPTION
- The timer goroutine committed to an unbuffered send on `out` once the timer fired and stopped selecting on `stop`. If the scheduler abandoned the timer at that moment - an insertion, a removal, a shutdown - its `stop()` sent on a channel nobody received from, and the scheduler goroutine hung for good.
- Close `stop` instead of sending on it. A close never blocks, so `stop()` returns whether or not the timer goroutine is still selecting. `sync.OnceFunc` keeps it idempotent rather than panicking on the second call.
- `out` is buffered so a goroutine that already committed to the send exits instead of parking forever.