### PR TITLE
fix(clock): TimerSkippingInstantExecutionClock.AdvanceTo hangs

### DIFF
--- a/timer_skipping_instant_execution_clock.go
+++ b/timer_skipping_instant_execution_clock.go
@@ -9,8 +9,9 @@ type TimerSkippingInstantExecutionClock struct {
 	mu   *sync.Mutex
 	now  time.Time
 	next struct {
-		time  time.Time
-		timer chan struct{}
+		time      time.Time
+		timer     chan struct{}
+		abandoned chan struct{}
 	}
 	sleeping struct {
 		value     bool
@@ -25,11 +26,13 @@ func NewTimerSkippingInstantExecutionClock(start time.Time) *TimerSkippingInstan
 		mu:  l,
 		now: start,
 		next: struct {
-			time  time.Time
-			timer chan struct{}
+			time      time.Time
+			timer     chan struct{}
+			abandoned chan struct{}
 		}{
-			time:  time.Time{},
-			timer: nil,
+			time:      time.Time{},
+			timer:     nil,
+			abandoned: nil,
 		},
 		sleeping: struct {
 			value     bool
@@ -59,14 +62,21 @@ func (c *TimerSkippingInstantExecutionClock) Now() time.Time {
 func (c *TimerSkippingInstantExecutionClock) Timer(t time.Time) (<-chan struct{}, func()) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	timer := make(chan struct{}, 1)
+	abandoned := make(chan struct{})
 	c.next.time = t
-	c.next.timer = make(chan struct{}, 1)
+	c.next.timer = timer
+	c.next.abandoned = abandoned
 	c.sleeping.value = true
 	c.sleeping.condition.Signal()
-	return c.next.timer, func() {
+	return timer, func() {
 		c.mu.Lock()
 		defer c.mu.Unlock()
 		c.sleeping.value = false
+		if len(timer) > 0 {
+			<-timer
+			close(abandoned)
+		}
 	}
 }
 
@@ -102,9 +112,13 @@ func (c *TimerSkippingInstantExecutionClock) AdvanceTo(target time.Time) {
 		}
 		c.now = c.next.time
 		c.sleeping.value = false
+		abandoned := c.next.abandoned
 		c.next.timer <- struct{}{}
 		close(c.next.timer)
 		c.mu.Unlock()
-		<-c.onCycleCompleted
+		select {
+		case <-c.onCycleCompleted:
+		case <-abandoned:
+		}
 	}
 }

--- a/timer_skipping_instant_execution_clock_test.go
+++ b/timer_skipping_instant_execution_clock_test.go
@@ -89,6 +89,41 @@ func TestJobTriggeredAfterAdvancingTwice(t *testing.T) {
 	}
 }
 
+func TestAdvanceSurvivesAbandonedActivation(t *testing.T) {
+	start := time.Date(2025, time.October, 7, 12, 0, 0, 0, time.UTC)
+	clock := NewTimerSkippingInstantExecutionClock(start)
+	clock.Register(New())
+
+	at := start.Add(time.Second)
+	timer, stop := clock.Timer(at)
+
+	advanced := make(chan struct{})
+	go func() {
+		clock.AdvanceBy(time.Second)
+		close(advanced)
+	}()
+
+	// Stand in for the scheduler waking on an insertion rather than on the timer: abandon the
+	// activation it already fired, re-arm at the same still-due time, then take the re-fire.
+	go func() {
+		for len(timer) == 0 {
+			time.Sleep(time.Millisecond)
+		}
+		stop()
+
+		refired, _ := clock.Timer(at)
+		<-refired
+		clock.onCycleCompleted <- struct{}{}
+		clock.Timer(at.Add(time.Second))
+	}()
+
+	select {
+	case <-advanced:
+	case <-time.After(2 * time.Second):
+		t.Fatal("AdvanceBy blocked forever on a cycle completion the abandoned activation never produces")
+	}
+}
+
 func TestNoJobsRegistered(t *testing.T) {
 	start := time.Date(2025, time.October, 7, 12, 0, 0, 0, time.UTC)
 	clock := NewTimerSkippingInstantExecutionClock(start)


### PR DESCRIPTION
## Problem
  
  - `AdvanceTo` fires by sending on the timer channel, then waits unconditionally for the cycle completion cron reports once it has consumed that fire.
  - When the scheduler wakes for an insertion, a removal or a shutdown instead, it abandons the fired activation and re-arms on a fresh channel.
  - The completion never arrives: `AdvanceTo`/`AdvanceBy` block for good.
  - Same family as #57
 
  ## Fix

  - Each arm now carries an `abandoned` channel alongside its timer; `AdvanceTo` waits for the cycle completion **or** that channel.
  - The `stop` callback is the hook - cron calls it on exactly the abandoning paths, and not on a snapshot, which keeps waiting on the same timer.
  - A value still buffered in the timer channel discriminates the abandoning wakes that had a fire in flight from the vast majority that had none; `stop` drains it and closes `abandoned`.
  - Per-arm rather than shared, so no signal can linger between advances, and `close` cannot block under the clock's mutex.
  - The activation is not lost: the scheduler re-arms at the same still-due time and `AdvanceTo`, released from the wait, fires it again.